### PR TITLE
Improve error handling on bytes error

### DIFF
--- a/app/js/custom/dependencies/CustomBufferController.js
+++ b/app/js/custom/dependencies/CustomBufferController.js
@@ -660,10 +660,13 @@ Custom.dependencies.CustomBufferController = function () {
                 clearTimeout(this.resetABRRestrictionsTimer);
                 this.resetABRRestrictionsTimer = undefined;
             }
+            if (!this.resetABRRestrictionsInterval) {
+                this.resetABRRestrictionsInterval = this.config.getParam("ABR.resetABRRestrictionsInterval", "number", 15000);
+            }
             this.resetABRRestrictionsTimer = setTimeout(function(){
                 self.debug.log("[BufferController]["+type+"] reset ABR maxQuality");
                 self.config.setParams(params);
-            }, 10000);
+            }, self.resetABRRestrictionsInterval);
 
             // finally check buffer again with new decreased quality level to fetch fragement of new quality level
             // Signal end of buffering process


### PR DESCRIPTION
In case of lost internet connection, corrupted or not available chunks on the CDN currently playback stops. This PR changes the behavior to switch to lower quality level and NOT stop scheduler in case of bytes error.

Additionally restrict ABR controller to not switch to unavailable quality level(s) for a certain time (configurable). (line 648 - 669) I know changing configuration at runtime is not a smart way but this was a clean way without changing a lot of files.
