### PR TITLE
Optimized zapping

### DIFF
--- a/app/js/streaming/AbrController.js
+++ b/app/js/streaming/AbrController.js
@@ -17,6 +17,7 @@ MediaPlayer.dependencies.AbrController = function () {
     var autoSwitchBitrate = true,
         qualityDict = {},
         confidenceDict = {},
+        playerState = "",
 
         getInternalQuality = function (type) {
             var quality;
@@ -169,7 +170,7 @@ MediaPlayer.dependencies.AbrController = function () {
                         self.abrRulesCollection.getRules().then(
                             function (rules) {
                                 for (i = 0, len = rules.length; i < len; i += 1) {
-                                    funcs.push(rules[i].checkIndex(quality, metrics, data));
+                                    funcs.push(rules[i].checkIndex(quality, metrics, data, playerState));
                                 }
                                 Q.all(funcs).then(
                                     function (results) {
@@ -313,6 +314,10 @@ MediaPlayer.dependencies.AbrController = function () {
 
         getQualityFor: function (type) {
             return getInternalQuality(type);
+        },
+
+        setPlayerState: function(state) {
+            playerState = state;
         }
     };
 };

--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -130,6 +130,9 @@ MediaPlayer.dependencies.BufferController = function () {
                 return;
             }
 
+            // Notify ABR controller we start the buffering in order to adapt ABR rules
+            self.abrController.setPlayerState("buffering");
+
             if (seeking === false) {
                 currentTime = new Date();
                 clearPlayListTraceMetrics(currentTime, MediaPlayer.vo.metrics.PlayList.Trace.USER_REQUEST_STOP_REASON);
@@ -869,6 +872,8 @@ MediaPlayer.dependencies.BufferController = function () {
             if (stalled) {
                 if (bufferLevel > minBufferTimeAtStartup) {
                     setStalled.call(self, false);
+                    // Notify ABR controller we are no more buffering before playing
+                    this.abrController.setPlayerState("playing");
                 }
             }
 

--- a/app/js/streaming/MetricsModel.js
+++ b/app/js/streaming/MetricsModel.js
@@ -50,7 +50,15 @@
         },
 
         clearCurrentMetricsForType: function (type) {
-            delete this.streamMetrics[type];
+            //delete this.streamMetrics[type];
+
+            for (var prop in this.streamMetrics[type]) {
+                // We keep HttpList in order to keep bandwidth conditions when switching the input stream
+                if (this.streamMetrics[type].hasOwnProperty(prop) && (prop !== "HttpList")) {
+                    this.streamMetrics[type][prop] = [];
+                }
+            }
+
             this.metricChanged(type);
         },
 
@@ -58,12 +66,12 @@
             var self = this;
 
             for (var prop in this.streamMetrics) {
-                if (this.streamMetrics.hasOwnProperty(prop)) {
+                if (this.streamMetrics.hasOwnProperty(prop) && (prop === "stream")) {
                     delete this.streamMetrics[prop];
                 }
             }
 
-            this.streamMetrics = {};
+            //this.streamMetrics = {};
             this.metricsChanged.call(self);
         },
 

--- a/app/js/streaming/rules/o/InsufficientBufferRule.js
+++ b/app/js/streaming/rules/o/InsufficientBufferRule.js
@@ -21,8 +21,9 @@ MediaPlayer.rules.o.InsufficientBufferRule = function () {    "use strict";
         metricsExt: undefined,
         manifestModel: undefined,
         config: undefined,
+        isStartBuffering: {},
 
-        checkIndex: function (current, metrics, data) {
+        checkIndex: function (current, metrics, data, playerState) {
             var self = this,
                 bufferLevel = self.metricsExt.getCurrentBufferLevel(metrics),
                 minBufferTime,
@@ -54,22 +55,35 @@ MediaPlayer.rules.o.InsufficientBufferRule = function () {    "use strict";
                     switchUpBufferRatio = self.config.getParamFor(data.type, "ABR.switchUpBufferRatio", "number", 0.75);
                     switchUpBufferTime = self.config.getParamFor(data.type, "ABR.switchUpBufferTime", "number", switchUpBufferRatio * minBufferTime);
 
-                    self.manifestExt.getRepresentationCount(data).then(
-                        function (max) {
-                            max -= 1; // 0 based
+                    // Check if we start buffering the stream. In this case we ignore the rule
+                    if (playerState === 'buffering') {
+                        self.isStartBuffering[data.type] = true;
+                    }
 
-                            if (bufferLevel.level <= switchLowerBufferTime) {
-                                q = 0;
-                                p = MediaPlayer.rules.SwitchRequest.prototype.STRONG;
-                            } else if (bufferLevel.level <= switchDownBufferTime) {
-                                q = (current > 0) ? (current - 1) : 0;
-                                p = MediaPlayer.rules.SwitchRequest.prototype.DEFAULT;
-                            }
-
-                            self.debug.log("[InsufficientBufferRule]["+data.type+"] SwitchRequest(" + q + ", " + p + ")");
-                            deferred.resolve(new MediaPlayer.rules.SwitchRequest(q, p));
+                    if ((bufferLevel.level < switchDownBufferTime) && (self.isStartBuffering[data.type])) {
+                        deferred.resolve(new MediaPlayer.rules.SwitchRequest());
+                    } else {
+                        if (bufferLevel.level >= switchDownBufferTime) {
+                            self.isStartBuffering[data.type] = false;
                         }
-                    );
+                        
+                        self.manifestExt.getRepresentationCount(data).then(
+                            function (max) {
+                                max -= 1; // 0 based
+
+                                if (bufferLevel.level <= switchLowerBufferTime) {
+                                    q = 0;
+                                    p = MediaPlayer.rules.SwitchRequest.prototype.STRONG;
+                                } else if (bufferLevel.level <= switchDownBufferTime) {
+                                    q = (current > 0) ? (current - 1) : 0;
+                                    p = MediaPlayer.rules.SwitchRequest.prototype.DEFAULT;
+                                }
+
+                                self.debug.log("[InsufficientBufferRule]["+data.type+"] SwitchRequest(" + q + ", " + p + ")");
+                                deferred.resolve(new MediaPlayer.rules.SwitchRequest(q, p));
+                            }
+                        );
+                    }
                 }
             );
 


### PR DESCRIPTION
Do not clear metrics regarding http requests in order to keep bandwidth conditions when switching to a new stream.