### PR TITLE
Replace xml2json by DOM parser

### DIFF
--- a/app/js/mss/MssParser.js
+++ b/app/js/mss/MssParser.js
@@ -17,9 +17,6 @@ Mss.dependencies.MssParser = function () {
     "use strict";
 
     var TIME_SCALE_100_NANOSECOND_UNIT = 10000000.0;
-
-    var numericRegex = /^[-+]?[0-9]+[.]?[0-9]*([eE][-+]?[0-9]+)?$/;
-    var hexadecimalRegex = /^0[xX][A-Fa-f0-9]+$/;
     var samplingFrequencyIndex = {96000:0x0,
                                   88200:0x1,
                                   64000:0x2,
@@ -34,48 +31,99 @@ Mss.dependencies.MssParser = function () {
                                    8000:0xB,
                                    7350:0xC};
 
-    var matchers = [
-        {
-            type: "numeric",
-            test: function (str) {
-                return numericRegex.test(str);
-            },
-            converter: function (str) {
-                return parseFloat(str);
-            }
-        },
-        {
-            type: "hexadecimal",
-            test: function (str) {
-                return hexadecimalRegex.test(str);
-            },
-            converter: function (str) {
-                // Remove '0x'
-                return str.substr(2);
-            }
-        }
-    ];
-
     var mimeTypeMap = {
         "video" : "video/mp4",
         "audio" : "audio/mp4",
         "text"  : "application/ttml+xml+mp4"
     };
 
+    var xmlDoc = null;
+    var baseURL = null;
 
-    var mapPeriod = function (manifest) {
+    var getAttributeValue = function(node, attrName) {
+        var returnValue = null,
+            domElem = null,
+            attribList = null;
+
+        attribList = node.attributes;
+        if(attribList){
+            domElem = attribList.getNamedItem(attrName);
+            if (domElem) {
+                returnValue = domElem.value;
+                return returnValue;
+            }
+        }
+
+        return returnValue;
+    };
+
+    var getChildNode = function(nodeParent, childName) {
+        var i = 0,
+            element = undefined;
+
+        if(nodeParent.childNodes){
+            for(i=0;i<nodeParent.childNodes.length;i++){
+                element = nodeParent.childNodes[i];
+                if (element.nodeName === childName) {
+                    return element;
+                }else{
+                    element = undefined;
+                }
+            }
+        }
+
+        return element;
+    };
+
+    var getChildNodes = function(nodeParent, childName) {
+        var i = 0,
+            element = [];
+
+        if(nodeParent.childNodes){
+            for(i=0;i<nodeParent.childNodes.length;i++){
+                if (nodeParent.childNodes[i].nodeName === childName) {
+                    element.push(nodeParent.childNodes[i]);
+                }
+            }
+        }
+
+        return element;
+    };
+    
+    var createXmlTree = function (xmlDocStr) {
+        if (window.DOMParser) {
+            // ORANGE: XML parsing management
+            try
+        {
+                var parser=new window.DOMParser();
+                xmlDoc = parser.parseFromString( xmlDocStr, "text/xml" );
+                if(xmlDoc.getElementsByTagName('parsererror').length > 0) {
+                      throw new Error('Error parsing XML');
+            }
+            }
+            catch (e)
+        {
+                return null;
+            }
+        }
+        return this;
+    };
+
+    var mapPeriod = function () {
         var period = {},
             adaptations = [],
+            streamIndex = null,
+            smoothNode = getChildNode(xmlDoc, "SmoothStreamingMedia"),
             i;
 
-        period.duration = (manifest.Duration === 0) ? Infinity : parseFloat(manifest.Duration) / TIME_SCALE_100_NANOSECOND_UNIT;
-        period.BaseURL = manifest.BaseURL;
+        period.duration = (getAttributeValue(smoothNode, 'Duration')) ? Infinity : parseFloat(getAttributeValue(smoothNode, 'Duration')) / TIME_SCALE_100_NANOSECOND_UNIT;
+        period.BaseURL = baseURL;
 
         // For each StreamIndex node, create an AdaptationSet element
-        for (i = 0; i < manifest.StreamIndex_asArray.length; i++) {
-            // Propagate BaseURL
-            manifest.StreamIndex_asArray[i].BaseURL = period.BaseURL;
-            adaptations.push(mapAdaptationSet(manifest.StreamIndex_asArray[i]));
+        for (i = 0; i < smoothNode.childNodes.length; i++) {
+            if (smoothNode.childNodes[i].nodeName === "StreamIndex") {
+                adaptations.push(mapAdaptationSet(smoothNode.childNodes[i]));
+            }
         }
 
         period.AdaptationSet = (adaptations.length > 1) ? adaptations : adaptations[0];
@@ -90,30 +138,32 @@ Mss.dependencies.MssParser = function () {
             representations = [],
             representation,
             segmentTemplate = {},
+            qualityLevels = null,
             i;
 
-        adaptationSet.id = streamIndex.Name;
-        adaptationSet.lang = streamIndex.Language;
-        adaptationSet.contentType = streamIndex.Type;
-        adaptationSet.mimeType = mimeTypeMap[streamIndex.Type];
-        adaptationSet.maxWidth = streamIndex.MaxWidth;
-        adaptationSet.maxHeight = streamIndex.MaxHeight;
-        adaptationSet.BaseURL = streamIndex.BaseURL;
+        adaptationSet.id = getAttributeValue(streamIndex, "Name");
+        adaptationSet.lang = getAttributeValue(streamIndex, "Language");
+        adaptationSet.contentType = getAttributeValue(streamIndex, "Type");
+        adaptationSet.mimeType = mimeTypeMap[adaptationSet.contentType];
+        adaptationSet.maxWidth =  getAttributeValue(streamIndex, "MaxWidth");
+        adaptationSet.maxHeight =  getAttributeValue(streamIndex, "MaxHeight");
+        adaptationSet.BaseURL = baseURL;
 
         // Create a SegmentTemplate with a SegmentTimeline
         segmentTemplate = mapSegmentTemplate(streamIndex);
 
+        qualityLevels = getChildNodes(streamIndex, "QualityLevel");
         // For each QualityLevel node, create a Representation element
-        for (i = 0; i < streamIndex.QualityLevel_asArray.length; i++) {
+        for (i = 0; i < qualityLevels.length; i++) {
             // Propagate BaseURL and mimeType
-            streamIndex.QualityLevel_asArray[i].BaseURL = adaptationSet.BaseURL;
-            streamIndex.QualityLevel_asArray[i].mimeType = adaptationSet.mimeType;
+            qualityLevels[i].BaseURL = adaptationSet.BaseURL;
+            qualityLevels[i].mimeType = adaptationSet.mimeType;
 
             // Set quality level id
-            streamIndex.QualityLevel_asArray[i].Id = adaptationSet.id + "_" + streamIndex.QualityLevel_asArray[i].Index;
+            qualityLevels[i].Id = adaptationSet.id + "_" + getAttributeValue(qualityLevels[i], "Index");
 
                 // Map Representation to QualityLevel
-                representation = mapRepresentation(streamIndex.QualityLevel_asArray[i]);
+            representation = mapRepresentation(qualityLevels[i]);
 
                 // Copy SegmentTemplate into Representation
                 representation.SegmentTemplate = segmentTemplate;
@@ -135,27 +185,29 @@ Mss.dependencies.MssParser = function () {
         var representation = {};
 
         representation.id = qualityLevel.Id;
-        representation.bandwidth = qualityLevel.Bitrate;
+        representation.bandwidth = parseInt(getAttributeValue(qualityLevel, "Bitrate"));
         representation.mimeType = qualityLevel.mimeType;
-        representation.width = qualityLevel.MaxWidth;
-        representation.height = qualityLevel.MaxHeight;
+        representation.width = parseInt(getAttributeValue(qualityLevel, "MaxWidth"));
+        representation.height = parseInt(getAttributeValue(qualityLevel, "MaxHeight"));
 
-        if (qualityLevel.FourCC === "H264" || qualityLevel.FourCC === "AVC1") {
+        var fourCCValue = getAttributeValue(qualityLevel, "FourCC");
+        
+        if (fourCCValue === "H264" || fourCCValue === "AVC1") {
             representation.codecs = getH264Codec(qualityLevel);
-        } else if (qualityLevel.FourCC.indexOf("AAC") >= 0){
+        } else if (fourCCValue.indexOf("AAC") >= 0){
             representation.codecs = getAACCodec(qualityLevel);
         }
 
-        representation.audioSamplingRate = qualityLevel.SamplingRate;
-        representation.audioChannels = qualityLevel.Channels;
-        representation.codecPrivateData = "" + qualityLevel.CodecPrivateData;
+        representation.audioSamplingRate =  parseInt(getAttributeValue(qualityLevel, "SamplingRate"));
+        representation.audioChannels =  parseInt(getAttributeValue(qualityLevel, "Channels"));
+        representation.codecPrivateData = "" + getAttributeValue(qualityLevel, "CodecPrivateData");
         representation.BaseURL = qualityLevel.BaseURL;
 
         return representation;
     };
 
     var getH264Codec = function (qualityLevel) {
-        var codecPrivateData = qualityLevel.CodecPrivateData.toString(),
+        var codecPrivateData = getAttributeValue(qualityLevel, "CodecPrivateData").toString(),
             nalHeader,
             avcoti;
 
@@ -172,26 +224,28 @@ Mss.dependencies.MssParser = function () {
 
     var getAACCodec = function (qualityLevel) {
         var objectType = 0,
-            codecPrivateData = qualityLevel.CodecPrivateData.toString(),
+            codecPrivateData = getAttributeValue(qualityLevel, "CodecPrivateData").toString(),
             codecPrivateDataHex,
+            fourCCValue = getAttributeValue(qualityLevel, "FourCC"),
+            samplingRate = parseInt(getAttributeValue(qualityLevel, "SamplingRate")),
             arr16;
 
         //chrome problem, in implicit AAC HE definition, so when AACH is detected in FourCC
         //set objectType to 5 => strange, it should be 2
-        if (qualityLevel.FourCC === "AACH") {
+        if (fourCCValue === "AACH") {
             objectType = 0x05;
         }
 
         //if codecPrivateData is empty, build it :
         if (codecPrivateData === undefined || codecPrivateData === "") {
             objectType = 0x02; //AAC Main Low Complexity => object Type = 2
-            var indexFreq = samplingFrequencyIndex[qualityLevel.SamplingRate];
-            if (qualityLevel.FourCC === "AACH") {
+            var indexFreq = samplingFrequencyIndex[samplingRate];
+            if (fourCCValue === "AACH") {
                 // 4 bytes :     XXXXX         XXXX          XXXX             XXXX                  XXXXX      XXX   XXXXXXX
                 //           ' ObjectType' 'Freq Index' 'Channels value'   'Extens Sampl Freq'  'ObjectType'  'GAS' 'alignment = 0'
                 objectType = 0x05; // High Efficiency AAC Profile = object Type = 5 SBR
                 codecPrivateData = new Uint8Array(4);
-                var extensionSamplingFrequencyIndex = samplingFrequencyIndex[qualityLevel.SamplingRate*2];// in HE AAC Extension Sampling frequence
+                var extensionSamplingFrequencyIndex = samplingFrequencyIndex[samplingRate*2];// in HE AAC Extension Sampling frequence
                 // equals to SamplingRate*2
                 //Freq Index is present for 3 bits in the first byte, last bit is in the second
                 codecPrivateData[0] = (objectType << 3) | (indexFreq >> 1);
@@ -212,7 +266,7 @@ Mss.dependencies.MssParser = function () {
                 codecPrivateData = new Uint8Array(2);
                 //Freq Index is present for 3 bits in the first byte, last bit is in the second
                 codecPrivateData[0] = (objectType << 3) | (indexFreq >> 1);
-                codecPrivateData[1] = (indexFreq << 7) | (qualityLevel.Channels << 3);
+                codecPrivateData[1] = (indexFreq << 7) | (parseInt(getAttributeValue(qualityLevel, "Channels")) << 3);
                 // put the 2 bytes in an 16 bits array
                 arr16 = new Uint16Array(1);
                 arr16[0] = (codecPrivateData[0] << 8) + codecPrivateData[1];
@@ -222,10 +276,11 @@ Mss.dependencies.MssParser = function () {
 
             codecPrivateData = "" + codecPrivateDataHex;
             codecPrivateData = codecPrivateData.toUpperCase();
-            qualityLevel.CodecPrivateData = codecPrivateData;
+            qualityLevel.setAttribute("CodecPrivateData", codecPrivateData);
         }
-        else if (objectType === 0)
+        else if (objectType === 0){
             objectType = (parseInt(codecPrivateData.substr(0, 2), 16) & 0xF8) >> 3;
+        }
 
         return "mp4a.40." + objectType;
     };
@@ -236,7 +291,7 @@ Mss.dependencies.MssParser = function () {
         var segmentTemplate = {},
             mediaUrl;
 
-        mediaUrl = streamIndex.Url.replace('{bitrate}','$Bandwidth$');
+        mediaUrl = getAttributeValue(streamIndex, "Url").replace('{bitrate}','$Bandwidth$');
         mediaUrl = mediaUrl.replace('{start time}','$Time$');
 
         segmentTemplate.media = mediaUrl;
@@ -250,36 +305,35 @@ Mss.dependencies.MssParser = function () {
     var mapSegmentTimeline = function (streamIndex) {
 
         var segmentTimeline = {},
-            chunks = streamIndex.c_asArray,
+            chunks = getChildNodes(streamIndex, "c"),
             segments = [],
             i = 0;
 
 
         if (chunks && chunks.length > 1) {
-
             // First pass on segments to update timestamp ('t') and duration ('d') fields
-            chunks[0].t = chunks[0].t || 0;
+            chunks[0].setAttribute('t', parseFloat(getAttributeValue(chunks[0], "t")) || 0);
             for (i = 1; i < chunks.length; i++) {
-                chunks[i-1].d = chunks[i-1].d || (chunks[i].t - chunks[i-1].t);
-                chunks[i].t = chunks[i].t || (chunks[i-1].t + chunks[i-1].d);
+                chunks[i-1].setAttribute('d', parseFloat(getAttributeValue(chunks[i-1], "d")) || ( parseFloat(getAttributeValue(chunks[i], "t")) -  parseFloat(getAttributeValue(chunks[i-1], "t"))));
+                chunks[i].setAttribute('t', parseFloat(getAttributeValue(chunks[i], "t")) || ( parseFloat(getAttributeValue(chunks[i-1], "t")) +  parseFloat(getAttributeValue(chunks[i-1], "d"))));
             }
 
             // Second pass to set SegmentTimeline template
             segments.push({
-                d : chunks[0].d,
+                d : parseFloat(getAttributeValue(chunks[0], "d")),
                 r: 0,
-                t: chunks[0].t
+                t: parseFloat(getAttributeValue(chunks[0], "t"))
             });
 
             for (i = 1; i < chunks.length; i++) {
-                if (chunks[i].d === chunks[i-1].d) {
+                if (parseFloat(getAttributeValue(chunks[i], "d")) === parseFloat(getAttributeValue(chunks[i-1], "d"))) {
                     // incrementation of the 'r' attributes
                     ++segments[segments.length -1].r;
                 } else {
                     segments.push({
-                        d : chunks[i].d,
+                        d : parseFloat(getAttributeValue(chunks[i], "d")),
                         r: 0,
-                        t: chunks[i].t
+                        t: parseFloat(getAttributeValue(chunks[i], "t"))
                     });
                 }
             }
@@ -299,7 +353,7 @@ Mss.dependencies.MssParser = function () {
             KID;
 
         // Get PlayReady header as byte array (base64 decoded)
-        prHeader = BASE64.decodeArray(protectionHeader.__text);
+        prHeader = BASE64.decodeArray(protectionHeader.firstChild.data);
 
         // Get Right Management header (WRMHEADER) from PlayReady header
         wrmHeader = getWRMHeaderFromPRHeader(prHeader);
@@ -383,10 +437,10 @@ Mss.dependencies.MssParser = function () {
         var contentProtection = {},
             keySystem = this.system.getObject("ksPlayReady"),
             pro,
-            systemID = protectionHeader.SystemID;
+            systemID = getAttributeValue(protectionHeader, "SystemID");
 
         pro = {
-            __text : protectionHeader.__text,
+            __text : protectionHeader.firstChild.data,
             __prefix : "mspr"
         };
 
@@ -420,21 +474,24 @@ Mss.dependencies.MssParser = function () {
     };
     /* @endif */
 
-    var processManifest = function (manifest, manifestLoadedTime) {
+    var processManifest = function (manifestLoadedTime) {
         var mpd = {},
             period,
             adaptations,
             contentProtection,
             contentProtections = [],
+            smoothNode = getChildNode(xmlDoc, "SmoothStreamingMedia"),
+            protection = getChildNode(smoothNode, 'Protection'),
+            protectionHeader = null,
             KID,
             i;
 
         // Set mpd node properties
         mpd.profiles = "urn:mpeg:dash:profile:isoff-live:2011";
-        mpd.type = manifest.IsLive ? "dynamic" : "static";
-        mpd.timeShiftBufferDepth = parseFloat(manifest.DVRWindowLength) / TIME_SCALE_100_NANOSECOND_UNIT;
-        mpd.mediaPresentationDuration =  (manifest.Duration === 0) ? Infinity : parseFloat(manifest.Duration) / TIME_SCALE_100_NANOSECOND_UNIT;
-        mpd.BaseURL = manifest.BaseURL;
+        mpd.type = Boolean(getAttributeValue(smoothNode, 'IsLive')) ? "dynamic" : "static";
+        mpd.timeShiftBufferDepth = parseFloat(getAttributeValue(smoothNode, 'DVRWindowLength')) / TIME_SCALE_100_NANOSECOND_UNIT;
+        mpd.mediaPresentationDuration =  (parseFloat(getAttributeValue(smoothNode, 'Duration')) === 0) ? Infinity : parseFloat(getAttributeValue(smoothNode, 'Duration')) / TIME_SCALE_100_NANOSECOND_UNIT;
+        mpd.BaseURL = baseURL;
         mpd.minBufferTime = MediaPlayer.dependencies.BufferExtensions.DEFAULT_MIN_BUFFER_TIME;
 
         // In case of live streams, set availabilityStartTime property according to DVRWindowLength
@@ -443,7 +500,7 @@ Mss.dependencies.MssParser = function () {
         }
 
         // Map period node to manifest root node
-        mpd.Period = mapPeriod(manifest);
+        mpd.Period = mapPeriod();
         mpd.Period_asArray = [mpd.Period];
 
         // Initialize period start time
@@ -451,21 +508,21 @@ Mss.dependencies.MssParser = function () {
         period.start = 0;
 
         // ContentProtection node
-        if (manifest.Protection !== undefined) {
+        if (protection !== undefined) {
             /* @if PROTECTION=true */
-
+            protectionHeader = getChildNode(protection, 'ProtectionHeader');
             // Get KID (in CENC format) from protection header
-            KID = getKIDFromProtectionHeader(manifest.Protection.ProtectionHeader);
+            KID = getKIDFromProtectionHeader(protectionHeader);
 
             // Create ContentProtection for PR
-            contentProtection = createPRContentProtection.call(this, manifest.Protection.ProtectionHeader);
+            contentProtection = createPRContentProtection.call(this, protectionHeader);
             contentProtection["cenc:default_KID"] = KID;
             contentProtections.push(contentProtection);
 
             // For chrome, create ContentProtection for Widevine as a CENC protection
             if (navigator.userAgent.indexOf("Chrome") >= 0) {
                 //contentProtections.push(createCENCContentProtection(manifest.Protection.ProtectionHeader));
-                contentProtection = createWidevineContentProtection.call(this, manifest.Protection.ProtectionHeader);
+                contentProtection = createWidevineContentProtection.call(this, protectionHeader);
                 contentProtection["cenc:default_KID"] = KID;
                 contentProtections.push(contentProtection);
             }
@@ -509,41 +566,28 @@ Mss.dependencies.MssParser = function () {
     var internalParse = function(data, baseUrl) {
         this.debug.info("[MssParser]", "Doing parse.");
 
-        var manifest = null,
-            converter = new X2JS(matchers, '', true),
-            start = new Date(),
-            json = null,
+        var start = new Date(),
+            xml = null,
+            manifest = null,
             mss2dash = null;
 
-        // Convert xml to json
         //this.debug.log("[MssParser]", "Converting from XML.");
-        manifest = converter.xml_str2json(data);
-        json = new Date();
+        createXmlTree(data);
+        xml = new Date();
 
-        if (manifest === null) {
+        if (xmlDoc === null) {
             this.debug.error("[MssParser]", "Failed to parse manifest!!");
             return Q.reject("[MssParser] Failed to parse manifest!!");
         }
 
-        // Set the manifest base Url
-        if (!manifest.hasOwnProperty("BaseURL")) {
-            this.debug.log("[MssParser]", "Setting baseURL: " + baseUrl);
-            manifest.BaseURL = baseUrl;
-        } else {
-            // Setting manifest's BaseURL to the first BaseURL
-            manifest.BaseURL = manifest.BaseURL_asArray && manifest.BaseURL_asArray[0] || manifest.BaseURL;
-
-            if (manifest.BaseURL.indexOf("http") !== 0) {
-                manifest.BaseURL = baseUrl + manifest.BaseURL;
-            }
-        }
+        baseURL = baseUrl;
 
         // Convert MSS manifest into DASH manifest
-        manifest = processManifest.call(this, manifest, start);
+        manifest = processManifest.call(this, start);
         mss2dash = new Date();
         //this.debug.log("mpd: " + JSON.stringify(manifest, null, '\t'));
 
-        this.debug.info("[MssParser]", "Parsing complete (xml2json: " + (json.getTime() - start.getTime()) + "ms, mss2dash: " + (mss2dash.getTime() - json.getTime()) + "ms, total: " + ((new Date().getTime() - start.getTime()) / 1000) + "s)");
+        this.debug.info("[MssParser]", "Parsing complete (xmlParser: " + (xml.getTime() - start.getTime()) + "ms, mss2dash: " + (mss2dash.getTime() - xml.getTime()) + "ms, total: " + ((new Date().getTime() - start.getTime()) / 1000) + "s)");
         //console.info("manifest",JSON.stringify(manifest) );
         return Q.when(manifest);
     };


### PR DESCRIPTION
In order to optimize zapping time, we use  DOM functions to access data in manifest file, no need to convert xml tree into json object.