### PR TITLE
Add compatibiltiy adjustments for some real-world MSS videos

### DIFF
--- a/app/js/mss/MssParser.js
+++ b/app/js/mss/MssParser.js
@@ -89,7 +89,7 @@ Mss.dependencies.MssParser = function () {
 
         return element;
     };
-    
+
     var createXmlTree = function (xmlDocStr) {
         if (window.DOMParser) {
             // ORANGE: XML parsing management
@@ -190,7 +190,7 @@ Mss.dependencies.MssParser = function () {
         representation.height = parseInt(getAttributeValue(qualityLevel, "MaxHeight"), 10);
 
         var fourCCValue = getAttributeValue(qualityLevel, "FourCC");
-        
+
         if (fourCCValue === "H264" || fourCCValue === "AVC1") {
             representation.codecs = getH264Codec(qualityLevel);
         } else if (fourCCValue.indexOf("AAC") >= 0){
@@ -323,13 +323,13 @@ Mss.dependencies.MssParser = function () {
                 if (!segments[segments.length - 1].d) {
                     segments[segments.length - 1].d = t - segments[segments.length - 1].t;
                 }
-                // Set segment absolute timestamp if not set 
+                // Set segment absolute timestamp if not set
                 if (!t) {
                     t = segments[segments.length - 1].t + segments[segments.length - 1].d;
                 }
             }
 
-            // Create new segment 
+            // Create new segment
             segments.push({
                 d: d,
                 r: 0,
@@ -509,6 +509,11 @@ Mss.dependencies.MssParser = function () {
         if (protection !== undefined) {
             /* @if PROTECTION=true */
             protectionHeader = getChildNode(protection, 'ProtectionHeader');
+
+            // Some packagers put newlines into the ProtectionHeader base64 string, which is not good
+            // because this cannot be correctly parsed. Let's just filter out any newlines found in there.
+            protectionHeader.firstChild.data = protectionHeader.firstChild.data.replace(/\n|\r/g, "");
+
             // Get KID (in CENC format) from protection header
             KID = getKIDFromProtectionHeader(protectionHeader);
 

--- a/app/js/streaming/ManifestLoader.js
+++ b/app/js/streaming/ManifestLoader.js
@@ -1,14 +1,14 @@
 /*
  * The copyright in this software is being made available under the BSD License, included below. This software may be subject to other third party and contributor rights, including patent rights, and no such rights are granted under this license.
- * 
+ *
  * Copyright (c) 2013, Digital Primates
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
  * •  Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
  * •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
  * •  Neither the name of the Digital Primates nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 MediaPlayer.dependencies.ManifestLoader = function () {
@@ -19,6 +19,30 @@ MediaPlayer.dependencies.ManifestLoader = function () {
         RETRY_INTERVAL = 500,
         deferred = null,
 
+        getDecodedResponseText = function (text) {
+            // Some content is not always successfully decoded by every browser.
+            // Known problem case: UTF-16 BE manifests on Internet Explorer 11.
+            // This function decodes any text that the browser failed to decode.
+            if (text.length < 1)
+                return text;
+
+            // The troublesome bit here is that IE still strips off the BOM, despite incorrectly decoding the file.
+            // So we will simply assume that the first character is < (0x3C) and detect its invalid decoding (0x3C00).
+            if (text.charCodeAt(0) !== 0x3C00)
+                return text;
+
+            // We have a problem!
+            var fixedCharCodes = [];
+
+            for (var i = 0; i < text.length; i++) {
+                var charCode = text.charCodeAt(i);
+
+                // Swap around the two bytes that make up the character code.
+                fixedCharCodes.push((charCode & 0xFF) << 8 | (charCode & 0xFF00) >> 8);
+            }
+
+            return String.fromCharCode.apply(null, fixedCharCodes);
+        },
 
         parseBaseUrl = function (url) {
             var base = null;
@@ -50,7 +74,7 @@ MediaPlayer.dependencies.ManifestLoader = function () {
                 }
 
                 self.debug.log("[ManifestLoader] Manifest downloaded");
-                
+
                 //ORANGE : Get the redirection URL and use it as base URL
                 if (request.responseURL) {
                   self.debug.log("[ManifestLoader] Redirect URL: " + request.responseURL);
@@ -73,7 +97,7 @@ MediaPlayer.dependencies.ManifestLoader = function () {
                                                  null,
                                                  null);
 
-                self.parser.parse(request.responseText, baseUrl).then(
+                self.parser.parse(getDecodedResponseText(request.responseText), baseUrl).then(
                     function (manifest) {
                         manifest.mpdUrl = url;
                         manifest.mpdLoadedTime = mpdLoadedTime;
@@ -119,7 +143,7 @@ MediaPlayer.dependencies.ManifestLoader = function () {
                         msgError = "Failed loading manifest: " + url + " no retry attempts left";
 
                     self.debug.log(msgError);
-                    
+
                     data.url = url;
                     data.request = request;
                     self.errHandler.sendError(MediaPlayer.dependencies.ErrorHandler.prototype.DOWNLOAD_ERR_MANIFEST, msgError, data);


### PR DESCRIPTION
We encountered some issues with data used by one of our customers, now fixed by these changes. The commit comments have more details but in essence:

* IE11 decodes UTF-16BE incorrectly as UTF-16LE. Hasplayer now detects and corrects this.
* ProtectionHeader may contain newline characters that must be filtered out before decoding.