### PR TITLE
Manifest url refresh

### DIFF
--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -1416,7 +1416,7 @@ MediaPlayer.dependencies.BufferController = function () {
         },
 
         updateManifest: function (){
-            this.system.notify("reloadManifest");
+            this.system.notify("manifestUpdate");
         },
 
         updateBufferState: function() {

--- a/app/js/streaming/MediaPlayer.js
+++ b/app/js/streaming/MediaPlayer.js
@@ -706,6 +706,19 @@ MediaPlayer = function(aContext) {
             }*/
         },
 
+         /**
+         * refresh manifest url
+         * @method refeshManifest
+         * @access public
+         * @memberof OrangeHasPlayer#
+         * param {string} url - the video stream's manifest (MPEG DASH, Smooth Streaming or HLS) url
+         */
+        refreshManifest: function(url){
+            if(streamController){
+                streamController.refreshManifest(url);
+            }
+        },
+
         /**
          * function used to stop video player, set source value to null and reset stream controller.
          * @access public

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -988,7 +988,6 @@ MediaPlayer.dependencies.Stream = function() {
         // ORANGE: add the capability to set audioTrack
         setAudioTrack: function(audioTrack) {
             var manifest = this.manifestModel.getValue(),
-                url,
                 self = this;
 
             if (audioController) {
@@ -1001,20 +1000,7 @@ MediaPlayer.dependencies.Stream = function() {
                             audioTrackIndex = index;
 
                             // Update manifest
-                            url = manifest.mpdUrl;
-
-                            if (manifest.hasOwnProperty("Location")) {
-                                url = manifest.Location;
-                            }
-
-                            self.debug.log("### Refresh manifest @ " + url);
-
-                            self.manifestLoader.load(url).then(
-                                function(manifestResult) {
-                                    self.manifestModel.setValue(manifestResult);
-                                    self.debug.log("### Manifest has been refreshed.");
-                                }
-                            );
+                            self.system.notify("manifestUpdate");
                         }
                     });
             }
@@ -1035,7 +1021,6 @@ MediaPlayer.dependencies.Stream = function() {
         setSubtitleTrack: function(subtitleTrack) {
             var deferredSubtitleUpdate = Q.defer(),
                 manifest = this.manifestModel.getValue(),
-                url,
                 self = this;
 
             if (textController) {
@@ -1044,22 +1029,8 @@ MediaPlayer.dependencies.Stream = function() {
                     function(index) {
                         textTrackIndex = index;
 
-                        // Update manifest
-                        url = manifest.mpdUrl;
-
-                        if (manifest.hasOwnProperty("Location")) {
-                            url = manifest.Location;
-                        }
-
-                        self.debug.log("### Refresh manifest @ " + url);
-
-                        self.manifestLoader.load(url).then(
-                            function(manifestResult) {
-                                self.manifestModel.setValue(manifestResult);
-                                self.debug.log("### Manifest has been refreshed.");
-                                deferredSubtitleUpdate.resolve();
-                            }
-                        );
+                       // Update manifest
+                        self.system.notify("manifestUpdate");
                     }
                 );
             } else {

--- a/app/js/streaming/StreamController.js
+++ b/app/js/streaming/StreamController.js
@@ -128,24 +128,6 @@
             }
         },
 
-        onReloadManifest = function() {
-            this.debug.log("[StreamController] ### reloadManifest ####");
-            
-            var manifest = this.manifestModel.getValue(),
-                url = manifest.mpdUrl,
-                self = this;
-
-            if (manifest.hasOwnProperty("Location")) {
-                url = manifest.Location;
-            }
-
-            self.manifestLoader.load(url).then(
-                function(manifestResult) {
-                    self.manifestModel.setValue(manifestResult);
-                    self.debug.log("### Manifest has been refreshed.");
-            });
-        },
-
         /*
          * Called when current playback positon is changed.
          * Used to determine the time current stream is finished and we should switch to the next stream.
@@ -412,6 +394,18 @@
             }
         },
 
+        manifestUpdate = function(){
+            var manifest = this.manifestModel.getValue(),
+                url = manifest.mpdUrl;
+
+            if (manifest.hasOwnProperty("Location")) {
+                url = manifest.Location;
+            } 
+
+            this.debug.log("### Refresh manifest @ " + url);
+            this.refreshManifest(url, true);
+        },
+
         manifestHasUpdated = function() {
             var self = this;
             composeStreams.call(self).then(
@@ -447,6 +441,7 @@
         metricsExt: undefined,
         videoExt: undefined,
         errHandler: undefined,
+        eventBus: undefined,
         notify: undefined,
         subscribe: undefined,
         unsubscribe: undefined,
@@ -456,15 +451,13 @@
         currentURL: undefined,
 
         setup: function() {
+            this.system.mapHandler("manifestUpdate",undefined, manifestUpdate.bind(this));
             this.system.mapHandler("manifestUpdated", undefined, manifestHasUpdated.bind(this));
             timeupdateListener = onTimeupdate.bind(this);
             progressListener = onProgress.bind(this);
             seekingListener = onSeeking.bind(this);
             pauseListener = onPause.bind(this);
             playListener = onPlay.bind(this);
-
-            //ORANGE
-            this.system.mapHandler("reloadManifest", undefined, onReloadManifest.bind(this));
         },
 
         getManifestExt: function () {
@@ -550,6 +543,28 @@
                 },
                 function () {
                     self.debug.error("[StreamController] Manifest loading error.");
+                }
+            );
+        },
+
+        refreshManifest: function(url, isIntern){
+            var self = this;
+            this.manifestLoader.load(url,true).then(
+                function(manifestResult) {
+                    self.manifestModel.setValue(manifestResult);
+                    self.debug.log("### Manifest has been refreshed.");
+                },
+                function(){
+                    // here notfiy webapp to refresh url
+                    if(isIntern){
+                        self.eventBus.dispatchEvent({
+                                type: "manifestUrlUpdate",
+                                data: url
+                        });
+                    }else{
+                        debugger;
+                        self.debug.warn("[StreamController] refreshManifest url : ", url , " is invalid !");
+                    }
                 }
             );
         },


### PR DESCRIPTION
Add mechanism to update/resfresh manifest url in the case it is no more valid (for example for signed urls).
Manifest refresh is for example required in MSS when switching audio/subtitles track.