### PR TITLE
Add compatibility updates for funky PlayReady CDM implementations

### DIFF
--- a/app/js/streaming/ManifestLoader.js
+++ b/app/js/streaming/ManifestLoader.js
@@ -41,7 +41,18 @@ MediaPlayer.dependencies.ManifestLoader = function () {
                 fixedCharCodes.push((charCode & 0xFF) << 8 | (charCode & 0xFF00) >> 8);
             }
 
-            return String.fromCharCode.apply(null, fixedCharCodes);
+            // We build the string in small chunks to avoid blowing the stack, as each argument needs
+            // to be given to fromCharCode separately on the stack, for some reason, leading to exceptions with large manfiests.
+            var fixedString = "";
+            var bufferSize = 1024;
+
+            for (i = 0; i < fixedCharCodes.length; i += bufferSize) {
+                var charCodeCount = Math.min(bufferSize, fixedCharCodes.length - i);
+
+                fixedString += String.fromCharCode.apply(null, fixedCharCodes.slice(i, i + charCodeCount));
+            }
+
+            return fixedString;
         },
 
         parseBaseUrl = function (url) {

--- a/app/js/streaming/protection/drm/KeySystem_PlayReady.js
+++ b/app/js/streaming/protection/drm/KeySystem_PlayReady.js
@@ -91,8 +91,14 @@ MediaPlayer.dependencies.protection.KeySystem_PlayReady = function() {
                 var Challenge = xmlDoc.getElementsByTagName("Challenge")[0].childNodes[0].nodeValue;
                 if (Challenge) {
                     licenseRequest = BASE64.decode(Challenge);
+                } else {
+                    // Some versions of the PlayReady CDM do not return the Microsoft-specified XML structure
+                    // but just return the raw license request. If we can't extract the license request, let's
+                    // assume it is the latter and just return the whole message.
+                    return msg;
                 }
             }
+            
             return licenseRequest;
         },
 

--- a/app/js/streaming/protection/drm/KeySystem_PlayReady.js
+++ b/app/js/streaming/protection/drm/KeySystem_PlayReady.js
@@ -67,6 +67,12 @@ MediaPlayer.dependencies.protection.KeySystem_PlayReady = function() {
                 headers['Content-Type'] = headers.Content;
                 delete headers.Content;
             }
+            // Some versions of the PlayReady CDM do not return headers at all, which means the Content-Type
+            // does not get set and most license servers will just refuse the license request. That's no good,
+            // so set it manually if it is missing.
+            if (!headers.hasOwnProperty('Content-Type')) {
+                headers['Content-Type'] = 'text/xml; charset=utf-8';
+            }
             return headers;
         },
 


### PR DESCRIPTION
We have recently been dealing with a device that has a custom implementation of PlayReady. While many of the changes we are doing to hasplayer appear to be too custom to be of wider benefit, I selected these two adjustments that are likely to also benefit the wider community using older PlayReady CDM implementations.

Specifically, this PlayReady CDM (presumably based on some old Microsoft sample code) does not follow the modern PlayReady CDM API and, instead of returning the Key Message structure as XML, it just returns the license request. This has a couple of implications, so fallback options need to be added to ensure that everything works OK even in such a case.