### PR TITLE
HLS discontinuities

### DIFF
--- a/app/js/hls/HlsDemux.js
+++ b/app/js/hls/HlsDemux.js
@@ -64,7 +64,7 @@ Hls.dependencies.HlsDemux = function() {
             pat = new mpegts.si.PAT();
             pat.parse(tsPacket.packet.getPayload());
 
-            this.debug.log("[HlsDemux] PAT: PMT_PID=" + pat.getPmtPid());
+            //this.debug.log("[HlsDemux] PAT: PMT_PID=" + pat.getPmtPid());
 
             return pat;
         },
@@ -84,7 +84,7 @@ Hls.dependencies.HlsDemux = function() {
             pmt = new mpegts.si.PMT();
             pmt.parse(tsPacket.packet.getPayload());
 
-            this.debug.log("[HlsDemux] PMT");
+            //this.debug.log("[HlsDemux] PMT");
 
             for (i = 0; i < pmt.m_listOfComponents.length; i++) {
                 elementStream = pmt.m_listOfComponents[i];
@@ -222,6 +222,16 @@ Hls.dependencies.HlsDemux = function() {
             for (i = 0; i < track.samples.length; i++) {
                 sample = track.samples[i];
 
+                // In case of ADTS, for each input sample (i.e. PES packet), we store the CTS (=PTS)
+                // in order to set the correct timestamp to each AAC frames after ADTS demultiplexing (see demuxADTS()),
+                // and then get around missing frames in input stream
+                if (track.streamType.search('ADTS') !== -1) {
+                    if (track.dataCTS === undefined) {
+                        track.dataCTS = [];
+                    }
+                    track.dataCTS[offset] = sample.cts;
+                }
+
                 // Copy all sub-sample parts into track data
                 for (s = 0; s < sample.subSamples.length; s++) {
                     track.data.set(sample.subSamples[s], offset);
@@ -235,8 +245,23 @@ Hls.dependencies.HlsDemux = function() {
             }
 
             // In case of AAC-ADTS stream, demultiplex ADTS frames into AAC frames
+            // (Demultiplexing is performed on the whole segment data in case ADTS packets are not aligned
+            // on PES packets)
             if (track.streamType.search('ADTS') !== -1) {
-                demuxADTS(track);
+                demuxADTS.call(this, track);
+            }
+
+            // Patch first frame timestamp and duration in case of missing frames at the end
+            // of the previous segment
+            if (track.previousCts && track.previousDuration) {
+                sample = track.samples[0];
+                var gap = sample.cts - (track.previousCts + track.previousDuration);
+                if (gap > 0) {
+                    sample.cts -= gap;
+                    sample.dts -= gap;
+                    sample.duration += gap;
+                    this.debug.log("[HlsDemux][" + track.type + "] Patch sample duration, cts = " + (sample.cts / 90000).toFixed(3) + ", duration = " + (sample.duration / 90000).toFixed(3));
+                }
             }
 
         },
@@ -253,7 +278,7 @@ Hls.dependencies.HlsDemux = function() {
                 i;
 
             // Parse AAC-ADTS access units and get AAC frames description
-            aacFrames = mpegts.aac.parseADTS(track.data);
+            aacFrames = mpegts.aac.parseADTS(track.data, track.dataCTS);
 
             // And determine total length of AAC frames
             length = 0;
@@ -275,11 +300,24 @@ Hls.dependencies.HlsDemux = function() {
             for (i = 0; i < aacFrames.length; i++) {
                 // Create sample
                 sample = new MediaPlayer.vo.Mp4Track.Sample();
-                sample.cts = sample.dts = cts;
+
+                // Set CTS according to ADTS frame CTS (=PES CTS) or according to sample duration
+                sample.cts = sample.dts = (aacFrames[i].cts ? aacFrames[i].cts : cts);
                 sample.size = aacFrames[i].length;
                 sample.duration = duration;
                 aacSamples.push(sample);
 
+                // Update cts for next frame
+                cts = sample.cts + duration;
+
+                // Update previous sample duration in case of missing frames
+                if (i > 0) {
+                    aacSamples[i-1].duration = aacSamples[i].cts - aacSamples[i-1].cts;
+                    if (aacSamples[i-1].duration > duration) {
+                        this.debug.log("[HlsDemux][" + track.type + "] Patch sample duration, cts = " + (aacSamples[i-1].cts / 90000).toFixed(3) + ", duration = " + (aacSamples[i-1].duration / 90000).toFixed(3));
+                    }
+                }
+                
                 // Copy AAC frame data
                 data.set(track.data.subarray(aacFrames[i].offset, aacFrames[i].offset + aacFrames[i].length), offset);
                 offset += aacFrames[i].length;
@@ -308,9 +346,13 @@ Hls.dependencies.HlsDemux = function() {
         },
 
         doInit = function(startTime) {
-            pat = null;
-            pmt = null;
-            tracks = [];
+            //pat = null;
+            //pmt = null;
+
+            // Reset codecs info to force setting new codecs (quality switch)
+            for (var i = 0; i < tracks.length; i++) {
+                tracks[i].codecs = "";
+            }
 
             if (dtsOffset === -1) {
                 dtsOffset = startTime;
@@ -391,8 +433,8 @@ Hls.dependencies.HlsDemux = function() {
                 track.codecPrivateData = codecPrivateDataHex.toUpperCase();*/
             }
 
-            this.debug.log("[HlsDemux][" + track.trackId + "] track codecPrivateData = " + track.codecPrivateData);
-            this.debug.log("[HlsDemux][" + track.trackId + "] track codecs = " + track.codecs);
+            this.debug.log("[HlsDemux][" + track.type + "] track codecPrivateData = " + track.codecPrivateData);
+            this.debug.log("[HlsDemux][" + track.type + "] track codecs = " + track.codecs);
 
             return track;
         },
@@ -427,6 +469,7 @@ Hls.dependencies.HlsDemux = function() {
 
         doDemux = function(data) {
             var nbPackets = data.length / mpegts.ts.TsPacket.prototype.TS_PACKET_SIZE,
+                track,
                 i = 0;
 
             this.debug.log("[HlsDemux] Demux chunk, size = " + data.length + ", nb packets = " + nbPackets);
@@ -443,6 +486,14 @@ Hls.dependencies.HlsDemux = function() {
 
             // Clear current tracks' data
             for (i = 0; i < tracks.length; i++) {
+                track = tracks[i];
+
+                // Store last sample timestamp and duration (in case of lost/missing samples)
+                if (track.samples.length > 0) {
+                    track.previousCts = track.samples[track.samples.length - 1].cts;
+                    track.previousDuration = track.samples[track.samples.length - 1].duration;
+                }
+
                 tracks[i].samples = [];
                 tracks[i].data = null;
             }
@@ -455,10 +506,11 @@ Hls.dependencies.HlsDemux = function() {
             }
 
             // Re-assemble samples from sub-samples
-            this.debug.log("[HlsDemux] Demux: baseDts = " + baseDts + ", dtsOffset = " + dtsOffset);
+            //this.debug.log("[HlsDemux] Demux: baseDts = " + baseDts + ", dtsOffset = " + dtsOffset);
             for (i = 0; i < tracks.length; i++) {
-                postProcess.call(this, tracks[i]);
-                this.debug.log("[HlsDemux][" + tracks[i].trackId + "] Demux: 1st PTS = " + tracks[i].samples[0].dts + " (" + (tracks[i].samples[0].dts / 90000) + ")");
+                track = tracks[i];
+                postProcess.call(this, track);
+                this.debug.log("[HlsDemux][" + track.type + "] Demux: 1st PTS = " + track.samples[0].dts + " (" + (track.samples[0].dts / 90000) + ")");
             }
 
             return tracks;

--- a/app/js/hls/HlsDemux.js
+++ b/app/js/hls/HlsDemux.js
@@ -219,6 +219,8 @@ Hls.dependencies.HlsDemux = function() {
             // Allocate track data
             track.data = new Uint8Array(length);
 
+            track.dataCTS = [];
+            
             for (i = 0; i < track.samples.length; i++) {
                 sample = track.samples[i];
 
@@ -226,9 +228,6 @@ Hls.dependencies.HlsDemux = function() {
                 // in order to set the correct timestamp to each AAC frames after ADTS demultiplexing (see demuxADTS()),
                 // and then get around missing frames in input stream
                 if (track.streamType.search('ADTS') !== -1) {
-                    if (track.dataCTS === undefined) {
-                        track.dataCTS = [];
-                    }
                     track.dataCTS[offset] = sample.cts;
                 }
 

--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -1563,12 +1563,12 @@ MediaPlayer.dependencies.BufferController = function() {
                                 ranges = this.sourceBufferExt.getAllRanges(buffer);
                                 var i;
                                 for (i = 0; i < ranges.length; i++) {
-                                    if (currentTime >= ranges.start(i) && currentTime <= ranges.end(i)) {
+                                    if (currentTime < ranges.start(i)) {
                                         break;
                                     }
                                 }
-                                if (i < (ranges.length - 1)) {
-                                    this.videoModel.setCurrentTime(ranges.start(i+1));
+                                if (i < ranges.length) {
+                                    this.videoModel.setCurrentTime(ranges.start(i));
                                 }
                             }
                         }

--- a/app/js/streaming/SourceBufferExtensions.js
+++ b/app/js/streaming/SourceBufferExtensions.js
@@ -72,7 +72,7 @@ MediaPlayer.dependencies.SourceBufferExtensions.prototype = {
             firstStart = null,
             lastEnd = null,
             gap = 0,
-            toler = (tolerance || 0.15),
+            toler = (tolerance || 0.01),
             len,
             i;
 

--- a/app/lib/mpegts/aac.js
+++ b/app/lib/mpegts/aac.js
@@ -64,7 +64,7 @@ mpegts.aac.getAudioSpecificConfig = function (data) { // data as Uint8Array
     return audioSpecificConfig;
 };
 
-mpegts.aac.parseADTS = function (data) { // data as Uint8Array
+mpegts.aac.parseADTS = function (data, cts) { // data as Uint8Array, cts as an array of cts for each frame index
 
     var aacFrames = [],
         adtsHeader = {},
@@ -107,6 +107,10 @@ mpegts.aac.parseADTS = function (data) { // data as Uint8Array
             aacFrame = {};
             aacFrame.offset = i;
             aacFrame.length = adtsHeader.aac_frame_length - (i - adtsFrameIndex);
+
+            if (cts && cts[adtsFrameIndex]) {
+                aacFrame.cts = cts[adtsFrameIndex];
+            }
 
             aacFrames.push(aacFrame);
 


### PR DESCRIPTION
Add robustness in case of input HLS streams discontinuities, i.e. with some missing aufio or video damples within the HLS fragments.
The input samples duration are patched in order to fill in discontinuities.
This PR adds some robustness also at BufferController level in order to skip discontinuites in the MSE SourceBuffers without stopiing the video.