### PR TITLE
feat: add setting sessionType via protData

### DIFF
--- a/app/js/streaming/protection/drm/KeySystem_PlayReady.js
+++ b/app/js/streaming/protection/drm/KeySystem_PlayReady.js
@@ -90,7 +90,7 @@ MediaPlayer.dependencies.protection.KeySystem_PlayReady = function() {
 
             msg = String.fromCharCode.apply(null, dataview);
             xmlDoc = this.domParser.createXmlTree(msg);
-            
+
             if (xmlDoc.getElementsByTagName("Challenge")[0]) {
                 Challenge = xmlDoc.getElementsByTagName("Challenge")[0].childNodes[0].nodeValue;
                 if (Challenge) {
@@ -263,9 +263,14 @@ MediaPlayer.dependencies.protection.KeySystem_PlayReady = function() {
         domParser: undefined,
         /*sessionType:"persistent-license",*/
         sessionType:"temporary",
-        
+
         init: function(protectionData){
-            protData = protectionData;
+            if(protectionData){
+                protData = protectionData;
+                if(protData.sessionType){
+                    sessionType = protData.sessionType;
+                }
+            }
         },
 
         getInitData: parseInitDataFromContentProtection,

--- a/app/js/streaming/protection/drm/KeySystem_PlayReady.js
+++ b/app/js/streaming/protection/drm/KeySystem_PlayReady.js
@@ -268,7 +268,7 @@ MediaPlayer.dependencies.protection.KeySystem_PlayReady = function() {
             if(protectionData){
                 protData = protectionData;
                 if(protData.sessionType){
-                    sessionType = protData.sessionType;
+                    this.sessionType = protData.sessionType;
                 }
             }
         },

--- a/app/js/streaming/protection/drm/KeySystem_Widevine.js
+++ b/app/js/streaming/protection/drm/KeySystem_Widevine.js
@@ -46,9 +46,9 @@ MediaPlayer.dependencies.protection.KeySystem_Widevine = function() {
             if(protData && protData.pssh){
                 return BASE64.decodeArray(protData.pssh).buffer;
             }
-            
+
             return MediaPlayer.dependencies.protection.CommonEncryption.parseInitDataFromContentProtection(cpData);
-            
+
         };
 
     return {
@@ -61,11 +61,14 @@ MediaPlayer.dependencies.protection.KeySystem_Widevine = function() {
         init:function(protectionData){
             if(protectionData){
                 protData = protectionData;
+                if(protData.sessionType){
+                    sessionType = protData.sessionType;
+                }
             }
         },
 
         getInitData: doGetInitData,
-        
+
         getKeySystemConfigurations: MediaPlayer.dependencies.protection.CommonEncryption.getKeySystemConfigurations,
 
         getRequestHeadersFromMessage: function(/*message*/) { return null; },

--- a/app/js/streaming/protection/drm/KeySystem_Widevine.js
+++ b/app/js/streaming/protection/drm/KeySystem_Widevine.js
@@ -62,7 +62,7 @@ MediaPlayer.dependencies.protection.KeySystem_Widevine = function() {
             if(protectionData){
                 protData = protectionData;
                 if(protData.sessionType){
-                    sessionType = protData.sessionType;
+                    this.sessionType = protData.sessionType;
                 }
             }
         },


### PR DESCRIPTION
changes the keysystem init function for Widevine & Playready to overwrite sessionType if supplied via protectiondata Object.  