### PR TITLE
Add DVR (NTC) support

### DIFF
--- a/app/js/mss/MssFragmentController.js
+++ b/app/js/mss/MssFragmentController.js
@@ -91,6 +91,11 @@ Mss.dependencies.MssFragmentController = function() {
                     segments.splice(0, 1);
                     segment = segments[0];
                 }
+
+                this.metricsModel.addDVRInfo(adaptation.type, 0, null, {
+                    start: segments[0].t / adaptation.SegmentTemplate.timescale,
+                    end: (segments[segments.length - 1].t + segments[segments.length - 1].d)  / adaptation.SegmentTemplate.timescale
+                });
             }
         },
 
@@ -243,6 +248,7 @@ Mss.dependencies.MssFragmentController = function() {
 
     rslt.manifestModel = undefined;
     rslt.manifestExt = undefined;
+    rslt.metricsModel = undefined;
 
     rslt.process = function(bytes, request, representations) {
         var result = null,

--- a/app/js/mss/MssParser.js
+++ b/app/js/mss/MssParser.js
@@ -74,6 +74,7 @@ Mss.dependencies.MssParser = function() {
                 representations = [],
                 representation,
                 segmentTemplate = {},
+                segments,
                 qualityLevels = null,
                 i;
 
@@ -118,6 +119,13 @@ Mss.dependencies.MssParser = function() {
 
             // Set SegmentTemplate
             adaptationSet.SegmentTemplate = segmentTemplate;
+
+            segments = segmentTemplate.SegmentTimeline.S_asArray;
+            this.metricsModel.addDVRInfo(adaptationSet.contentType, 0, null, {
+                start: segments[0].t / segmentTemplate.timescale,
+                end: (segments[segments.length - 1].t + segments[segments.length - 1].d)  / segmentTemplate.timescale
+            });
+
 
             return adaptationSet;
         },
@@ -551,6 +559,7 @@ Mss.dependencies.MssParser = function() {
         system: undefined,
         errHandler: undefined,
         domParser: undefined,
+        metricsModel: undefined,
 
         parse: internalParse
     };

--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -122,9 +122,10 @@ MediaPlayer.dependencies.BufferController = function() {
             stalled = value;
             self.videoModel.stallStream(type, stalled);
 
-            // Notify ABR controller we start buffering or playing in order to adapt ABR rules
-            self.abrController.setPlayerState(stalled ? "buffering" : "playing");
-
+            // Notify ABR controller we start buffering in order to adapt ABR rules (see InsufficientbufferRule)
+            if (stalled) {
+                self.abrController.setPlayerState("buffering");
+            }
         },
 
         startPlayback = function() {
@@ -936,7 +937,7 @@ MediaPlayer.dependencies.BufferController = function() {
         getWorkingTime = function() {
             var time = -1;
 
-            if (this.videoModel.isPaused()) {
+            if (this.videoModel.isPaused() || seeking) {
                 time = seekTarget;
             } else {
                 time = this.videoModel.getCurrentTime();

--- a/app/js/streaming/ManifestModel.js
+++ b/app/js/streaming/ManifestModel.js
@@ -14,7 +14,7 @@
 MediaPlayer.models.ManifestModel = function () {
     "use strict";
 
-    var manifest;
+    var manifest = null;
 
     return {
         system: undefined,

--- a/app/js/streaming/MediaPlayer.js
+++ b/app/js/streaming/MediaPlayer.js
@@ -189,6 +189,14 @@ MediaPlayer = function(aContext) {
             return val;
         },
 
+        getDVRWindowRange = function () {
+            var metric = this.metricsModel.getReadOnlyMetricsFor('video'),
+                dvrInfo = metric ? this.metricsExt.getCurrentDVRInfo(metric) : null,
+                range = dvrInfo ? dvrInfo.range : null;
+
+            return range;
+        },
+
         /**
          * seek to a special time (seconds) in the stream.
          * html5 video currentTime parameter is better to use than this function.
@@ -776,6 +784,7 @@ MediaPlayer = function(aContext) {
         durationAsUTC: durationAsUTC,
         getDVRWindowSize: getDVRWindowSize,
         getDVRSeekOffset: getDVRSeekOffset,
+        getDVRWindowRange: getDVRWindowRange,
         formatUTC: formatUTC,
         convertToTimeCode: convertToTimeCode
 

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -101,6 +101,8 @@ MediaPlayer.dependencies.Stream = function() {
 
             this.debug.info("[Stream] Do seek: " + time);
 
+            this.videoModel.pause();
+            
             // Performs a programmatical seek:
             // 1- seeks the buffer controllers at the desired time
             // 2- once data is present in the buffers, then we can set the current time to the <video> component (see onBufferUpdated()) 

--- a/samples/Dash-IF/index.html
+++ b/samples/Dash-IF/index.html
@@ -150,16 +150,17 @@
     <script src="../../app/js/streaming/vo/URIFragmentData.js"></script>
     <!-- /app/js/streaming/vo/metrics -->
     <script src="../../app/js/streaming/vo/metrics/BufferLevel.js"></script>
+    <script src="../../app/js/streaming/vo/metrics/BufferedSwitch.js"></script>
+    <script src="../../app/js/streaming/vo/metrics/Condition.js"></script>
     <script src="../../app/js/streaming/vo/metrics/DroppedFrames.js"></script>
+    <script src="../../app/js/streaming/vo/metrics/DVRInfo.js"></script>
     <script src="../../app/js/streaming/vo/metrics/HTTPRequest.js"></script>
     <script src="../../app/js/streaming/vo/metrics/ManifestUpdate.js"></script>
     <script src="../../app/js/streaming/vo/metrics/PlayList.js"></script>
     <script src="../../app/js/streaming/vo/metrics/RepresentationSwitch.js"></script>
-    <script src="../../app/js/streaming/vo/metrics/BufferedSwitch.js"></script>
-    <script src="../../app/js/streaming/vo/metrics/TCPConnection.js"></script>
-    <script src="../../app/js/streaming/vo/metrics/State.js"></script>
     <script src="../../app/js/streaming/vo/metrics/Session.js"></script>
-    <script src="../../app/js/streaming/vo/metrics/Condition.js"></script>
+    <script src="../../app/js/streaming/vo/metrics/State.js"></script>
+    <script src="../../app/js/streaming/vo/metrics/TCPConnection.js"></script>
     <!-- /app/js/dash -->
     <script src="../../app/js/dash/Dash.js"></script>
     <script src="../../app/js/dash/BaseURLExtensions.js"></script>

--- a/samples/DemoPlayer/index.html
+++ b/samples/DemoPlayer/index.html
@@ -578,16 +578,17 @@
 <script src="../../app/js/streaming/vo/URIFragmentData.js"></script>
 <!-- /app/js/streaming/vo/metrics -->
 <script src="../../app/js/streaming/vo/metrics/BufferLevel.js"></script>
+<script src="../../app/js/streaming/vo/metrics/BufferedSwitch.js"></script>
+<script src="../../app/js/streaming/vo/metrics/Condition.js"></script>
 <script src="../../app/js/streaming/vo/metrics/DroppedFrames.js"></script>
+<script src="../../app/js/streaming/vo/metrics/DVRInfo.js"></script>
 <script src="../../app/js/streaming/vo/metrics/HTTPRequest.js"></script>
 <script src="../../app/js/streaming/vo/metrics/ManifestUpdate.js"></script>
 <script src="../../app/js/streaming/vo/metrics/PlayList.js"></script>
 <script src="../../app/js/streaming/vo/metrics/RepresentationSwitch.js"></script>
-<script src="../../app/js/streaming/vo/metrics/BufferedSwitch.js"></script>
-<script src="../../app/js/streaming/vo/metrics/TCPConnection.js"></script>
-<script src="../../app/js/streaming/vo/metrics/State.js"></script>
 <script src="../../app/js/streaming/vo/metrics/Session.js"></script>
-<script src="../../app/js/streaming/vo/metrics/Condition.js"></script>
+<script src="../../app/js/streaming/vo/metrics/State.js"></script>
+<script src="../../app/js/streaming/vo/metrics/TCPConnection.js"></script>
 <!-- /app/js/dash -->
 <script src="../../app/js/dash/Dash.js"></script>
 <script src="../../app/js/dash/BaseURLExtensions.js"></script>

--- a/samples/playerSrc.html
+++ b/samples/playerSrc.html
@@ -121,16 +121,18 @@
 <script src="../../app/js/streaming/vo/URIFragmentData.js"></script>
 <!-- /app/js/streaming/vo/metrics -->
 <script src="../../app/js/streaming/vo/metrics/BufferLevel.js"></script>
+<script src="../../app/js/streaming/vo/metrics/BufferedSwitch.js"></script>
+<script src="../../app/js/streaming/vo/metrics/Condition.js"></script>
 <script src="../../app/js/streaming/vo/metrics/DroppedFrames.js"></script>
+<script src="../../app/js/streaming/vo/metrics/DVRInfo.js"></script>
 <script src="../../app/js/streaming/vo/metrics/HTTPRequest.js"></script>
 <script src="../../app/js/streaming/vo/metrics/ManifestUpdate.js"></script>
 <script src="../../app/js/streaming/vo/metrics/PlayList.js"></script>
 <script src="../../app/js/streaming/vo/metrics/RepresentationSwitch.js"></script>
-<script src="../../app/js/streaming/vo/metrics/BufferedSwitch.js"></script>
-<script src="../../app/js/streaming/vo/metrics/TCPConnection.js"></script>
-<script src="../../app/js/streaming/vo/metrics/State.js"></script>
 <script src="../../app/js/streaming/vo/metrics/Session.js"></script>
-<script src="../../app/js/streaming/vo/metrics/Condition.js"></script>
+<script src="../../app/js/streaming/vo/metrics/State.js"></script>
+<script src="../../app/js/streaming/vo/metrics/TCPConnection.js"></script>
+
 <!-- /app/js/dash -->
 <script src="../../app/js/dash/Dash.js"></script>
 <script src="../../app/js/dash/BaseURLExtensions.js"></script>


### PR DESCRIPTION
Add DVR (NTC) support.
This functionnality can be used with the "DEMO PLAYER" sample in which the control and seek/progress bar has been redefined, enabling seeking for live streams.

For example:
http://orange-opensource.github.io/hasplayer.js/dev/player.html?url=http://2is7server1.rd.francetelecom.com/C4/C4-51_BBB.isml/Manifest