### PR TITLE
Trick mode

### DIFF
--- a/app/js/dash/DashHandler.js
+++ b/app/js/dash/DashHandler.js
@@ -1174,6 +1174,10 @@ Dash.dependencies.DashHandler = function() {
             );
 
             return deferred.promise;
+        },
+
+        getIFrameRequest = function(request) {
+            //TBD
         };
 
     return {
@@ -1209,7 +1213,8 @@ Dash.dependencies.DashHandler = function() {
         getNextSegmentRequestFromSN: getNextFromSN,
         getCurrentTime: getCurrentTime,
         getSegmentCountForDuration: getSegmentCountForDuration,
-        updateSegmentList: updateSegmentList
+        updateSegmentList: updateSegmentList,
+        getIFrameRequest: getIFrameRequest 
     };
 };
 

--- a/app/js/dash/DashHandler.js
+++ b/app/js/dash/DashHandler.js
@@ -15,7 +15,7 @@ Dash.dependencies.DashHandler = function() {
     "use strict";
 
     var index = -1,
-        requestedTime,
+        requestedTime = null,
         isDynamic,
         type,
         offset = null,
@@ -505,7 +505,7 @@ Dash.dependencies.DashHandler = function() {
                 return range;
             }
 
-            if (!isDynamic && requestedTime) {
+            if (!isDynamic && requestedTime !== null) {
                 return null;
             }
 

--- a/app/js/mss/MssFragmentController.js
+++ b/app/js/mss/MssFragmentController.js
@@ -116,7 +116,6 @@ Mss.dependencies.MssFragmentController = function() {
                 saiz = null,
                 tfdt = null,
                 tfrf = null,
-                sdtp = null,
                 sizedifferent = false,
                 pos = -1,
                 fragment_size = 0,
@@ -230,24 +229,21 @@ Mss.dependencies.MssFragmentController = function() {
                     concatDuration = 0,
                     mdatData = mdat.data;
 
-                sdtp = traf.getBoxByType("sdtp");
-
                 //we have to duplicate the sample from KeyFrame request to be accepted by decoder.
-                //all the samples have to have a duration equals to request.duration * request.timescale
-                var sampleDuration = Math.floor(fullDuration / sdtp.sample_dependency_array.length);
-
-                trun.samples_table[0].sample_duration = sampleDuration;
-                for (i = 0; i < (sdtp.sample_dependency_array.length - 1); i++) {
+                //all the samples have to have a duration equals to request.duration * request.timescale               
+                var trunEntries = Math.floor(fullDuration / trun.samples_table[0].sample_duration);
+                
+                for (i = 0; i < (trunEntries - 1); i++) {
                     if (request.streamType === 'video') {
                         trun.samples_table.push({
-                            sample_duration: sampleDuration,
+                            sample_duration: trun.samples_table[0].sample_duration,
                             sample_size: trun.samples_table[0].sample_size,
                             sample_composition_time_offset: trun.samples_table[0].sample_composition_time_offset,
                             sample_flags: trun.samples_table[0].sample_flags
                         });
                     } else {
                         trun.samples_table.push({
-                            sample_duration: sampleDuration,
+                            sample_duration: trun.samples_table[0].sample_duration,
                             sample_size: trun.samples_table[0].sample_size
                         });
                     }

--- a/app/js/mss/MssFragmentController.js
+++ b/app/js/mss/MssFragmentController.js
@@ -227,11 +227,18 @@ Mss.dependencies.MssFragmentController = function() {
             if (this.fixDuration && trun.samples_table.length === 1) {
                 var fullDuration = request.duration * request.timescale,
                     concatDuration = 0,
-                    mdatData = mdat.data;
+                    mdatData = mdat.data,
+                    sampleDuration;
 
+                //if sample_duration is not defined, search duration in tfhd box
+                if (trun.samples_table[0].sample_duration === undefined) {
+                    sampleDuration = tfhd.default_sample_duration;
+                }else{
+                    sampleDuration = trun.samples_table[0].sample_duration;
+                }
                 //we have to duplicate the sample from KeyFrame request to be accepted by decoder.
                 //all the samples have to have a duration equals to request.duration * request.timescale               
-                var trunEntries = Math.floor(fullDuration / trun.samples_table[0].sample_duration);
+                var trunEntries = Math.floor(fullDuration / sampleDuration);
                 
                 for (i = 0; i < (trunEntries - 1); i++) {
                     if (request.streamType === 'video') {

--- a/app/js/mss/MssFragmentController.js
+++ b/app/js/mss/MssFragmentController.js
@@ -218,7 +218,7 @@ Mss.dependencies.MssFragmentController = function() {
             trun.flags |= 0x000001; // set trun.data-offset-present to true
             trun.data_offset = 0; // Set a default value for trun.data_offset
 
-            if (this.fixDuration && request.streamType === 'video') {
+            if (this.fixDuration && request.streamType === 'video' && trun.samples_table.length === 1) {
                 trun.samples_table[0].sample_duration = request.duration * request.timescale;
                 this.debug.log("[MssFragmentController] convertFragment  fix sample Duration = " + trun.samples_table[0].sample_duration);
             }

--- a/app/js/mss/MssFragmentController.js
+++ b/app/js/mss/MssFragmentController.js
@@ -91,11 +91,6 @@ Mss.dependencies.MssFragmentController = function() {
                     segments.splice(0, 1);
                     segment = segments[0];
                 }
-
-                this.metricsModel.addDVRInfo(adaptation.type, 0, null, {
-                    start: segments[0].t / adaptation.SegmentTemplate.timescale,
-                    end: (segments[segments.length - 1].t + segments[segments.length - 1].d)  / adaptation.SegmentTemplate.timescale
-                });
             }
         },
 
@@ -223,6 +218,11 @@ Mss.dependencies.MssFragmentController = function() {
             trun.flags |= 0x000001; // set trun.data-offset-present to true
             trun.data_offset = 0; // Set a default value for trun.data_offset
 
+            if (this.fixDuration && request.streamType === 'video') {
+                trun.samples_table[0].sample_duration = request.duration * request.timescale;
+                this.debug.log("[MssFragmentController] convertFragment  fix sample Duration = " + trun.samples_table[0].sample_duration);
+            }
+
             // Determine new size of the converted fragment
             // and allocate new data buffer
             fragment_size = fragment.getLength();
@@ -248,7 +248,7 @@ Mss.dependencies.MssFragmentController = function() {
 
     rslt.manifestModel = undefined;
     rslt.manifestExt = undefined;
-    rslt.metricsModel = undefined;
+    rslt.fixDuration = false;
 
     rslt.process = function(bytes, request, representations) {
         var result = null,
@@ -273,6 +273,10 @@ Mss.dependencies.MssFragmentController = function() {
         }
 
         return Q.when(result);
+    };
+
+    rslt.setSampleDuration = function(state) {
+        this.fixDuration = state;
     };
 
     return rslt;

--- a/app/js/mss/MssHandler.js
+++ b/app/js/mss/MssHandler.js
@@ -144,7 +144,7 @@ Mss.dependencies.MssHandler = function() {
     };
 
     rslt.getIFrameRequest = function(request){
-        if (request && request.url && (request.url.indexOf('video') !== -1 || request.url.indexOf('audio') !== -1)) {
+        if (request && request.url && (request.streamType === "video" || request.streamType === "audio")) {
             request.url = request.url.replace('Fragments','KeyFrames');
         }
 

--- a/app/js/mss/MssHandler.js
+++ b/app/js/mss/MssHandler.js
@@ -142,6 +142,15 @@ Mss.dependencies.MssHandler = function() {
 
         return deferred.promise;
     };
+
+    rslt.getIFrameRequest = function(request){
+        if (request && request.url && request.url.indexOf('video') !== -1 ) {
+            request.url = request.url.replace('Fragments','KeyFrames');
+        }
+
+        return request;
+    };
+
     return rslt;
 };
 

--- a/app/js/mss/MssHandler.js
+++ b/app/js/mss/MssHandler.js
@@ -144,7 +144,7 @@ Mss.dependencies.MssHandler = function() {
     };
 
     rslt.getIFrameRequest = function(request){
-        if (request && request.url && request.url.indexOf('video') !== -1 ) {
+        if (request && request.url && (request.url.indexOf('video') !== -1 || request.url.indexOf('audio') !== -1)) {
             request.url = request.url.replace('Fragments','KeyFrames');
         }
 

--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -1685,11 +1685,13 @@ MediaPlayer.dependencies.BufferController = function() {
             trickModePreviousQuality = trickModeEnabled ? self.abrController.getQualityFor(type) : trickModePreviousQuality;
             self.abrController.setAutoSwitchBitrate(!trickModeEnabled);
             self.abrController.setPlaybackQuality(type, (trickModeEnabled ? 0 : trickModePreviousQuality));
-            removeBuffer.call(this, 0, (trickModeEnabled ? self.videoModel.getCurrentTime() : -1)).then(function() {
-                self.debug.log("[BufferController][" + type + "] buffer cleared");
-                debugBufferRange.call(self);
+            if (trickModeEnabled) {
                 deferred.resolve();
-            });
+            } else {
+                removeBuffer.call(this).then(function() {
+                    deferred.resolve();
+                });
+            }
 
             return deferred.promise;
         },

--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -1545,6 +1545,10 @@ MediaPlayer.dependencies.BufferController = function() {
                 return;
             }
 
+            if (trickModeEnabled) {
+                return;
+            }
+
             //this.debug.log("#### [" + type + "] level = " + bufferLevel + ", currentTime = " + currentTime + ", progress = " + progress);
 
             switch (htmlVideoState) {

--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -1030,6 +1030,12 @@ MediaPlayer.dependencies.BufferController = function() {
             timeToEnd = getTimeToEnd.call(self);
             self.debug.log("[BufferController][" + type + "] time to end = " + timeToEnd);
 
+            //for trick mode, buffer needs to be filled faster
+            if(trickModeEnabled){
+                if (bufferLevel<1) {
+                    bufferFragment.call(self);
+                }
+            }else{
             if (languageChanged ||
                 ((bufferLevel < minBufferTime) &&
                     ((minBufferTime < timeToEnd) || (minBufferTime >= timeToEnd && !isBufferingCompleted)))) {
@@ -1040,6 +1046,7 @@ MediaPlayer.dependencies.BufferController = function() {
                 delay = bufferLevel - minBufferTime;
                 self.debug.log("[BufferController][" + type + "] Check buffer in " + delay + " seconds");
                 updateCheckBufferTimeout.call(self, delay);
+            }
             }
         },
 

--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -302,6 +302,9 @@ MediaPlayer.dependencies.BufferController = function() {
                         // ORANGE : For HLS Stream, init segment are pushed with media (@see HlsFragmentController)
                         loadNextFragment.call(self);
                     }
+                }, function(e) {
+                    signalSegmentBuffered.call(self);
+                    self.errHandler.sendError(MediaPlayer.dependencies.ErrorHandler.prototype.INTERNAL_ERROR, "Internal error while processing media segment", e.message);
                 }
             );
         },
@@ -1109,9 +1112,9 @@ MediaPlayer.dependencies.BufferController = function() {
                                                 signalSegmentBuffered.call(self);
                                                 if (e.name === MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_ERR_CODEC_UNSUPPORTED) {
                                                     self.errHandler.sendError(e.name, e.message, e.data);
+                                                } else {
+                                                    self.errHandler.sendError(MediaPlayer.dependencies.ErrorHandler.prototype.INTERNAL_ERROR, "Internal error while processing initialization segment", e.message);
                                                 }
-                                                // TODO: manage not available init segment request (internal error?)
-                                                // TODO: discard unsupported representations
                                             }
                                         );
                                     } else {

--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -1635,9 +1635,9 @@ MediaPlayer.dependencies.BufferController = function() {
 
             self.fragmentController.setSampleDuration(trickModeEnabled);
             trickModePreviousQuality = trickModeEnabled ? self.abrController.getQualityFor(type) : trickModePreviousQuality;
-            self.abrController.setAutoSwitchBitrate(!trickModeEnabled);
             self.abrController.setPlaybackQuality(type, (trickModeEnabled ? 0 : trickModePreviousQuality));
             if (trickModeEnabled) {
+                self.abrController.setAutoSwitchBitrate(false);
                 deferred.resolve();
             } else {
                 removeBuffer.call(this).then(function() {

--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -1657,12 +1657,12 @@ MediaPlayer.dependencies.BufferController = function() {
             return lastDownloadedSegmentDuration;
         },
 
-        setTrickPlay: function(enabled) {
+        setTrickMode: function(enabled) {
             var self = this,
                 deferred = Q.defer();
 
 
-            this.debug.log("[BufferController][" + type + "] setTrickPlay - enabled = " + enabled);
+            this.debug.log("[BufferController][" + type + "] setTrickMode - enabled = " + enabled);
 
             trickModeEnabled = enabled;
 

--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -53,6 +53,7 @@ MediaPlayer.dependencies.BufferController = function() {
         minBufferTimeAtStartup,
         bufferTimeout,
         bufferStateTimeout,
+        trickModeEnabled = false,
 
         playListMetrics = null,
         playListTraceMetrics = null,
@@ -894,6 +895,10 @@ MediaPlayer.dependencies.BufferController = function() {
                     self.debug.log("[BufferController][" + type + "] new fragment request => already loaded or pending");
                     self.indexHandler.getNextSegmentRequest(_currentRepresentation).then(onFragmentRequest.bind(self));
                 } else {
+                    //if trick mode enbaled, get the request to get I Frame data.
+                    if (trickModeEnabled) {
+                        request = self.indexHandler.getIFrameRequest(request);
+                    }
                     // Store current segment time for next segment request
                     currentSegmentTime = request.startTime;
 
@@ -1653,11 +1658,11 @@ MediaPlayer.dependencies.BufferController = function() {
                     if (speed > 1) {
                         deferred.resolve();
                         self.fragmentController.setSampleDuration(true);
-                        fragmentModel.fragmentLoader.activateKeyReq(true);
+                        trickModeEnabled = true;
                         self.videoModel.setPlaybackRate(speed);
                     } else {
+                        trickModeEnabled = false;
                         self.fragmentController.setSampleDuration(false);
-                        fragmentModel.fragmentLoader.activateKeyReq(false);
                         self.videoModel.setPlaybackRate(speed);
                         removeBuffer.call(this).then(function() {
                             debugBufferRange.call(self);

--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -749,10 +749,10 @@ MediaPlayer.dependencies.BufferController = function() {
             // Abandonned request => load segment at lowest quality
             if (e.aborted) {
                 // if (e.quality !== 0) {
-                    // this.debug.info("[BufferController][" + type + "] Segment download abandonned => Retry segment download at lowest quality");
-                    // this.abrController.setAutoSwitchBitrate(false);
-                    // this.abrController.setPlaybackQuality(type, 0);
-                    bufferFragment.call(this);
+                // this.debug.info("[BufferController][" + type + "] Segment download abandonned => Retry segment download at lowest quality");
+                // this.abrController.setAutoSwitchBitrate(false);
+                // this.abrController.setPlaybackQuality(type, 0);
+                bufferFragment.call(this);
                 // }
                 return;
             }
@@ -1537,7 +1537,7 @@ MediaPlayer.dependencies.BufferController = function() {
                     } else if (!this.getVideoModel().isStalled()) {
                         ranges = this.sourceBufferExt.getAllRanges(buffer);
                         if (ranges.length > 0) {
-                            var gap = getWorkingTime.call(this) - ranges.end(ranges.length-1);
+                            var gap = getWorkingTime.call(this) - ranges.end(ranges.length - 1);
                             this.debug.log("[BufferController][" + type + "] BUFFERING - delay from current time = " + gap);
                             if (gap > 4) {
                                 this.debug.log("[BufferController][" + type + "] BUFFERING => reload session");
@@ -1638,6 +1638,45 @@ MediaPlayer.dependencies.BufferController = function() {
                 }
             );
 
+            return deferred.promise;
+        },
+
+        setTrickPlay: function(speed) {
+            var self = this,
+                deferred = Q.defer();
+
+
+            this.debug.log("[BufferController][" + type + "] setTrickPlay - speed = " + speed);
+
+            switch (type) {
+                case 'video':
+                    if (speed > 1) {
+                        deferred.resolve();
+                        self.fragmentController.setSampleDuration(true);
+                        fragmentModel.fragmentLoader.activateKeyReq(true);
+                        self.videoModel.setPlaybackRate(speed);
+                    } else {
+                        self.fragmentController.setSampleDuration(false);
+                        fragmentModel.fragmentLoader.activateKeyReq(false);
+                        self.videoModel.setPlaybackRate(speed);
+                        removeBuffer.call(this).then(function() {
+                            debugBufferRange.call(self);
+                            deferred.resolve();
+                        });
+
+                    }
+                    break;
+                case 'audio':
+                    if (speed > 1) {
+                        deferred.resolve();
+                    } else {
+                        removeBuffer.call(this).then(function() {
+                            debugBufferRange.call(self);
+                            deferred.resolve();
+                        });
+                    }
+                    break;
+            }
             return deferred.promise;
         },
 

--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -906,7 +906,7 @@ MediaPlayer.dependencies.BufferController = function() {
                     // Download the segment
                     self.fragmentController.prepareFragmentForLoading(self, request, onBytesLoadingStart, onBytesLoaded, onBytesError, null /*signalStreamComplete*/ ).then(
                         function() {
-                                sendRequest.call(self);
+                            sendRequest.call(self);
                         });
                 }
             } else {
@@ -1514,7 +1514,7 @@ MediaPlayer.dependencies.BufferController = function() {
         updateBufferState: function() {
             var self = this,
                 currentTime = this.videoModel.getCurrentTime(),
-                previousTime = htmlVideoTime === -1? currentTime : htmlVideoTime,
+                previousTime = htmlVideoTime === -1 ? currentTime : htmlVideoTime,
                 progress = (currentTime - previousTime),
                 ranges;
 
@@ -1647,31 +1647,24 @@ MediaPlayer.dependencies.BufferController = function() {
             return deferred.promise;
         },
 
-        setTrickPlay: function(speed) {
+        setTrickPlay: function(enabled) {
             var self = this,
                 deferred = Q.defer();
 
 
-            this.debug.log("[BufferController][" + type + "] setTrickPlay - speed = " + speed);
+            this.debug.log("[BufferController][" + type + "] setTrickPlay - enabled = " + enabled);
 
-            switch (type) {
-                case 'video':
-                case 'audio':
-                    if (speed > 1) {
-                        deferred.resolve();
-                        self.fragmentController.setSampleDuration(true);
-                        trickModeEnabled = true;
-                        self.videoModel.setPlaybackRate(speed);
-                    } else {
-                        trickModeEnabled = false;
-                        self.fragmentController.setSampleDuration(false);
-                        self.videoModel.setPlaybackRate(speed);
-                        removeBuffer.call(this).then(function() {
-                            debugBufferRange.call(self);
-                            deferred.resolve();
-                        });
-                    }
-                    break;
+            trickModeEnabled = enabled;
+
+            if (enabled) {
+                deferred.resolve();
+                self.fragmentController.setSampleDuration(true);
+            } else {
+                self.fragmentController.setSampleDuration(false);
+                removeBuffer.call(this).then(function() {
+                    debugBufferRange.call(self);
+                    deferred.resolve();
+                });
             }
             return deferred.promise;
         },

--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -273,7 +273,7 @@ MediaPlayer.dependencies.BufferController = function() {
 
                         // if this is the initialization data for current quality we need to push it to the buffer
                         self.debug.info("[BufferController][" + type + "] Buffer initialization segment ", (request.url !== null) ? request.url : request.quality);
-                        //console.saveBinArray(data, type + "_init_" + request.quality + ".mp4");
+                        //    console.saveBinArray(data, type + "_init_" + request.quality + ".mp4");
                         // Clear the buffer if required (language track switching)
                         clearBuffer.call(self).then(
                             function() {
@@ -340,7 +340,7 @@ MediaPlayer.dependencies.BufferController = function() {
                         }
 
                         self.debug.info("[BufferController][" + type + "] Buffer segment from url ", request.url);
-                        //console.saveBinArray(data, type + "_" + request.index + "_" + request.quality + ".mp4");
+                        //    console.saveBinArray(data, type + "_" + request.index + "_" + request.quality + ".mp4");
                         deleteInbandEvents.call(self, data).then(
                             function(data) {
                                 appendToBuffer.call(self, data, request.quality, request.index).then(
@@ -1036,28 +1036,35 @@ MediaPlayer.dependencies.BufferController = function() {
                     bufferFragment.call(self);
                 }
             }else{
-            if (languageChanged ||
-                ((bufferLevel < minBufferTime) &&
-                    ((minBufferTime < timeToEnd) || (minBufferTime >= timeToEnd && !isBufferingCompleted)))) {
-                // Buffer needs to be filled
-                bufferFragment.call(self);
-            } else {
-                // Determine the timeout delay before checking again the buffer
-                delay = bufferLevel - minBufferTime;
-                self.debug.log("[BufferController][" + type + "] Check buffer in " + delay + " seconds");
-                updateCheckBufferTimeout.call(self, delay);
-            }
+                if (languageChanged ||
+                    ((bufferLevel < minBufferTime) &&
+                        ((minBufferTime < timeToEnd) || (minBufferTime >= timeToEnd && !isBufferingCompleted)))) {
+                    // Buffer needs to be filled
+                    bufferFragment.call(self);
+                } else {
+                    // Determine the timeout delay before checking again the buffer
+                    delay = bufferLevel - minBufferTime;
+                    self.debug.log("[BufferController][" + type + "] Check buffer in " + delay + " seconds");
+                    updateCheckBufferTimeout.call(self, delay);
+                }
             }
         },
 
         updateCheckBufferTimeout = function(delay) {
-            var self = this;
+            var self = this,
+                delayMs =  Math.max((delay * 1000), 2000);
+            
+            self.debug.log("[BufferController][" + type + "] Check buffer delta = " + delayMs + " ms");
+
+           /* if (trickModeEnabled) {
+                delayMs = 500;
+            }*/
 
             clearTimeout(bufferTimeout);
             bufferTimeout = setTimeout(function() {
                 bufferTimeout = null;
                 checkIfSufficientBuffer.call(self);
-            }, Math.max((delay * 1000), 2000));
+            }, delayMs);
         },
 
         cancelCheckBufferTimeout = function() {

--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -896,16 +896,17 @@ MediaPlayer.dependencies.BufferController = function() {
                     self.indexHandler.getNextSegmentRequest(_currentRepresentation).then(onFragmentRequest.bind(self));
                 } else {
                     //if trick mode enbaled, get the request to get I Frame data.
-                    if (trickModeEnabled && type === 'video') {
+                    if (trickModeEnabled) {
                         request = self.indexHandler.getIFrameRequest(request);
                     }
+                   
                     // Store current segment time for next segment request
                     currentSegmentTime = request.startTime;
 
                     // Download the segment
                     self.fragmentController.prepareFragmentForLoading(self, request, onBytesLoadingStart, onBytesLoaded, onBytesError, null /*signalStreamComplete*/ ).then(
                         function() {
-                            sendRequest.call(self);
+                                sendRequest.call(self);
                         });
                 }
             } else {
@@ -1655,6 +1656,7 @@ MediaPlayer.dependencies.BufferController = function() {
 
             switch (type) {
                 case 'video':
+                case 'audio':
                     if (speed > 1) {
                         deferred.resolve();
                         self.fragmentController.setSampleDuration(true);
@@ -1664,19 +1666,6 @@ MediaPlayer.dependencies.BufferController = function() {
                         trickModeEnabled = false;
                         self.fragmentController.setSampleDuration(false);
                         self.videoModel.setPlaybackRate(speed);
-                        removeBuffer.call(this).then(function() {
-                            debugBufferRange.call(self);
-                            deferred.resolve();
-                        });
-
-                    }
-                    break;
-                case 'audio':
-                    if (speed > 1) {
-                        trickModeEnabled = true;
-                        deferred.resolve();
-                    } else {
-                        trickModeEnabled = false;
                         removeBuffer.call(this).then(function() {
                             debugBufferRange.call(self);
                             deferred.resolve();

--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -896,7 +896,7 @@ MediaPlayer.dependencies.BufferController = function() {
                     self.indexHandler.getNextSegmentRequest(_currentRepresentation).then(onFragmentRequest.bind(self));
                 } else {
                     //if trick mode enbaled, get the request to get I Frame data.
-                    if (trickModeEnabled) {
+                    if (trickModeEnabled && type === 'video') {
                         request = self.indexHandler.getIFrameRequest(request);
                     }
                     // Store current segment time for next segment request
@@ -1673,8 +1673,10 @@ MediaPlayer.dependencies.BufferController = function() {
                     break;
                 case 'audio':
                     if (speed > 1) {
+                        trickModeEnabled = true;
                         deferred.resolve();
                     } else {
+                        trickModeEnabled = false;
                         removeBuffer.call(this).then(function() {
                             debugBufferRange.call(self);
                             deferred.resolve();

--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -1664,6 +1664,10 @@ MediaPlayer.dependencies.BufferController = function() {
 
             this.debug.log("[BufferController][" + type + "] setTrickMode - enabled = " + enabled);
 
+            if (trickModeEnabled === enabled) {
+                deferred.resolve();
+                return deferred.promise;
+            }
             trickModeEnabled = enabled;
 
             if (enabled) {

--- a/app/js/streaming/ErrorHandler.js
+++ b/app/js/streaming/ErrorHandler.js
@@ -42,6 +42,9 @@ MediaPlayer.dependencies.ErrorHandler.prototype = {
 };
 
 // <video> element errors
+MediaPlayer.dependencies.ErrorHandler.prototype.INTERNAL_ERROR = "INTERNAL_ERROR";
+
+// <video> element errors
 MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_ERR_ABORTED = "MEDIA_ERR_ABORTED";
 MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_ERR_NETWORK = "MEDIA_ERR_NETWORK";
 MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_ERR_DECODE = "MEDIA_ERR_DECODE";

--- a/app/js/streaming/FragmentLoader.js
+++ b/app/js/streaming/FragmentLoader.js
@@ -80,6 +80,11 @@ MediaPlayer.dependencies.FragmentLoader = function() {
 
             lastTraceTime = request.requestStartDate;
 
+            //get Intra
+            if (self.activatedKeyReq && request.url.indexOf('video') !== -1 ) {
+                request.url = request.url.replace('Fragments','KeyFrames');
+            }
+
             req.open("GET", self.tokenAuthentication.addTokenAsQueryArg(request.url), true);
             req.responseType = "arraybuffer";
             req = self.tokenAuthentication.setTokenInRequestHeader(req);
@@ -166,7 +171,7 @@ MediaPlayer.dependencies.FragmentLoader = function() {
                 if (xhrs.indexOf(req) === -1) {
                     return;
                 }
-
+                
                 xhrs.splice(xhrs.indexOf(req), 1);
                 
                 if (!needFailureReport) {
@@ -233,6 +238,7 @@ MediaPlayer.dependencies.FragmentLoader = function() {
         notify: undefined,
         subscribe: undefined,
         unsubscribe: undefined,
+        activatedKeyReq: false,
 
         setup: function() {
             retryAttempts = this.config.getParam("FragmentLoader.RetryAttempts", "number", DEFAULT_RETRY_ATTEMPTS);
@@ -291,7 +297,11 @@ MediaPlayer.dependencies.FragmentLoader = function() {
             _checkForExistence.call(this, req);
 
             return req.deferred.promise;
-        }
+        },
+
+        activateKeyReq: function(state){
+            this.activatedKeyReq = state;
+        },
     };
 };
 

--- a/app/js/streaming/FragmentLoader.js
+++ b/app/js/streaming/FragmentLoader.js
@@ -80,11 +80,6 @@ MediaPlayer.dependencies.FragmentLoader = function() {
 
             lastTraceTime = request.requestStartDate;
 
-            //get Intra
-            if (self.activatedKeyReq && request.url.indexOf('video') !== -1 ) {
-                request.url = request.url.replace('Fragments','KeyFrames');
-            }
-
             req.open("GET", self.tokenAuthentication.addTokenAsQueryArg(request.url), true);
             req.responseType = "arraybuffer";
             req = self.tokenAuthentication.setTokenInRequestHeader(req);
@@ -238,7 +233,6 @@ MediaPlayer.dependencies.FragmentLoader = function() {
         notify: undefined,
         subscribe: undefined,
         unsubscribe: undefined,
-        activatedKeyReq: false,
 
         setup: function() {
             retryAttempts = this.config.getParam("FragmentLoader.RetryAttempts", "number", DEFAULT_RETRY_ATTEMPTS);
@@ -297,11 +291,7 @@ MediaPlayer.dependencies.FragmentLoader = function() {
             _checkForExistence.call(this, req);
 
             return req.deferred.promise;
-        },
-
-        activateKeyReq: function(state){
-            this.activatedKeyReq = state;
-        },
+        }
     };
 };
 

--- a/app/js/streaming/MediaPlayer.js
+++ b/app/js/streaming/MediaPlayer.js
@@ -775,9 +775,17 @@ MediaPlayer = function(aContext) {
         },
 
         setTrickModeSpeed: function(speed){
-            if(streamController){
+            if (streamController) {
                 streamController.setTrickModeSpeed(speed);
             }
+        },
+
+        getTrickModeSpeed: function() {
+            if (streamController) {
+                return streamController.getTrickModeSpeed();
+            }
+
+            return 0;
         },
 
         play: play,

--- a/app/js/streaming/MediaPlayer.js
+++ b/app/js/streaming/MediaPlayer.js
@@ -774,9 +774,9 @@ MediaPlayer = function(aContext) {
             defaultSubtitleLang = language;
         },
 
-        setTrickPlay: function(speed){
+        setTrickModeSpeed: function(speed){
             if(streamController){
-                streamController.setTrickPlay(speed);
+                streamController.setTrickModeSpeed(speed);
             }
         },
 

--- a/app/js/streaming/MediaPlayer.js
+++ b/app/js/streaming/MediaPlayer.js
@@ -776,7 +776,11 @@ MediaPlayer = function(aContext) {
 
         setTrickModeSpeed: function(speed){
             if (streamController) {
-                streamController.setTrickModeSpeed(speed);
+                if (streamController.getTrickModeSpeed() !== speed && speed === 1) {
+                    videoModel.play();
+                }else{
+                    streamController.setTrickModeSpeed(speed);
+                }
             }
         },
 

--- a/app/js/streaming/MediaPlayer.js
+++ b/app/js/streaming/MediaPlayer.js
@@ -774,6 +774,11 @@ MediaPlayer = function(aContext) {
             defaultSubtitleLang = language;
         },
 
+        setTrickPlay: function(speed){
+            if(streamController){
+                streamController.setTrickPlay(speed);
+            }
+        },
 
         play: play,
         isReady: isReady,

--- a/app/js/streaming/MediaPlayer.js
+++ b/app/js/streaming/MediaPlayer.js
@@ -774,9 +774,9 @@ MediaPlayer = function(aContext) {
             defaultSubtitleLang = language;
         },
 
-        setTrickPlay: function(speed){
+        setTrickPlay: function(enabled){
             if(streamController){
-                streamController.setTrickPlay(speed);
+                streamController.setTrickPlay(enabled);
             }
         },
 

--- a/app/js/streaming/MediaPlayer.js
+++ b/app/js/streaming/MediaPlayer.js
@@ -774,9 +774,9 @@ MediaPlayer = function(aContext) {
             defaultSubtitleLang = language;
         },
 
-        setTrickPlay: function(enabled){
+        setTrickPlay: function(speed){
             if(streamController){
-                streamController.setTrickPlay(enabled);
+                streamController.setTrickPlay(speed);
             }
         },
 

--- a/app/js/streaming/Mp4Processor.js
+++ b/app/js/streaming/Mp4Processor.js
@@ -978,7 +978,7 @@ MediaPlayer.dependencies.Mp4Processor = function() {
                 trafs,
                 mdatLength = 0,
                 trackglobal = {},
-                mdatTracksTab,
+                mdatTracksTab = [],
                 offset = 0;
 
             // Create file
@@ -989,10 +989,12 @@ MediaPlayer.dependencies.Mp4Processor = function() {
 
             // Create Movie Fragment Header box (moof) 
             moof.boxes.push(createMovieFragmentHeaderBox(sequenceNumber));
-
-            for (i = 0; i < tracks.length; i += 1) {
-                // Create Track Fragment box (traf)
-                moof.boxes.push(createTrackFragmentBox(tracks[i]));
+            
+            if (tracks) {
+                for (i = 0; i < tracks.length; i += 1) {
+                    // Create Track Fragment box (traf)
+                    moof.boxes.push(createTrackFragmentBox(tracks[i]));
+                }
             }
 
             moof_file.boxes.push(moof);
@@ -1005,18 +1007,22 @@ MediaPlayer.dependencies.Mp4Processor = function() {
 
             length += 8; // 8 = 'size' + 'type' mdat fields length
 
-            // mdat array size = tracks.length
-            mdatTracksTab = [tracks.length];
+            if (tracks && tracks.length) {
+                // mdat array size = tracks.length
+                mdatTracksTab = [tracks.length];
+            }
 
-            for (i = 0; i < tracks.length; i += 1) {
-                // Update trun.data_offset for the track
-                trafs[i].getBoxByType("trun").data_offset = length;
-                // Update length of output fragment file
-                length += tracks[i].data.length;
-                // Add current data in mdatTracksTab array
-                mdatTracksTab[i] = tracks[i].data;
-                // Update length of global mdat
-                mdatLength += mdatTracksTab[i].length;
+            if (tracks) {
+                for (i = 0; i < tracks.length; i += 1) {
+                    // Update trun.data_offset for the track
+                    trafs[i].getBoxByType("trun").data_offset = length;
+                    // Update length of output fragment file
+                    length += tracks[i].data.length;
+                    // Add current data in mdatTracksTab array
+                    mdatTracksTab[i] = tracks[i].data;
+                    // Update length of global mdat
+                    mdatLength += mdatTracksTab[i].length;
+                }
             }
 
             trackglobal.data = new Uint8Array(mdatLength);

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -73,6 +73,7 @@ MediaPlayer.dependencies.Stream = function() {
         // trick mode variables
         tmState = "Stopped",
         tmSpeed = 1,
+        tmPreviousSpeed,
         tmStartTime,
         tmVideoStartTime,
         tmMinSeekStep,
@@ -1405,7 +1406,7 @@ MediaPlayer.dependencies.Stream = function() {
             self.debug.info("[Stream] Trick mode: speed = " + speed);
 
             if (enableTrickMode && tmState === "Stopped") {
-                self.debug.info("[Stream] Set mute: false");
+                self.debug.info("[Stream] Set mute: true");
                 self.videoModel.setMute(true);
                 self.videoModel.pause();
                 self.videoModel.listen("seeked", seekedListener);
@@ -1433,7 +1434,6 @@ MediaPlayer.dependencies.Stream = function() {
                     self.videoModel.listen("timeupdate", enableMute);
                     seek.call(self, currentVideoTime, true);
                 } else {
-                    self.debug.info("[Stream] Trick mode: speed = " + tmSpeed);
                     if (tmState === "Running") {
                         tmState = "Changed";
                     }

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -1326,7 +1326,7 @@ MediaPlayer.dependencies.Stream = function() {
             }
         },
 
-        setTrickPlay: function(speed) {
+        setTrickModeSpeed: function(speed) {
             var funcs = [],
                 self = this,
                 trickModeEnabled = speed != 1 ? true : false;
@@ -1334,16 +1334,16 @@ MediaPlayer.dependencies.Stream = function() {
             trickModeSpeed = speed;
 
             if (videoController) {
-                funcs.push(videoController.setTrickPlay(trickModeEnabled));
+                funcs.push(videoController.setTrickMode(trickModeEnabled));
             }
             if (audioController) {
-                funcs.push(audioController.setTrickPlay(trickModeEnabled));
+                funcs.push(audioController.setTrickMode(trickModeEnabled));
             }
 
             Q.all(funcs).then(function() {
                 var currentTime = self.videoModel.getCurrentTime();
                 if (!trickModeEnabled) {
-                    self.debug.info("[Stream] setTrickPlay disabled seek to " + currentTime);
+                    self.debug.info("[Stream] setTrickModeSpeed disabled seek to " + currentTime);
                     trickModeSeekValue = 0;
                     self.videoModel.listen("seeking", seekingListener);
                     self.videoModel.unlisten("seeked", seekedListener);

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -522,10 +522,12 @@ MediaPlayer.dependencies.Stream = function() {
             if (tmSpeed !== 1) {
                 this.setTrickModeSpeed(1);
             } else {
-                // set the currentTime here to be sure that videoTag is ready to accept the seek (cause IE fail on set currentTime on BufferUpdate)
+                // Set the currentTime here to be sure that videoTag is ready to accept the seek (cause IE fail on set currentTime on BufferUpdate)
                 if (playStartTime > 0) {
                     setVideoModelCurrentTime.call(this, playStartTime);
                     playStartTime = -1;
+                } else {
+                    startBuffering.call(this);
                 }
             }
 
@@ -647,6 +649,9 @@ MediaPlayer.dependencies.Stream = function() {
                 };
 
             this.debug.info("[Stream] <video> seeked event");
+
+            // Notify BufferControllers that video has seeked
+            seekedBuffers.call(this);
 
             // Trick mode
             if (tmSpeed !== 1) {
@@ -787,6 +792,18 @@ MediaPlayer.dependencies.Stream = function() {
             }
             if (textController) {
                 textController.stop();
+            }
+        },
+
+        seekedBuffers = function() {
+            if (videoController) {
+                videoController.seeked();
+            }
+            if (audioController) {
+                audioController.seeked();
+            }
+            if (textController) {
+                textController.seeked();
             }
         },
 

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -525,6 +525,8 @@ MediaPlayer.dependencies.Stream = function() {
             this.debug.info("<video> play event");
             this.debug.log("[Stream] Got play event.");
 
+            this.setTrickModeSpeed(1);
+
             // set the currentTime here to be sure that videoTag is ready to accept the seek (cause IE fail on set currentTime on BufferUpdate)
             if (currentTimeToSet !== 0) {
                 this.system.notify("setCurrentTime");
@@ -1335,11 +1337,15 @@ MediaPlayer.dependencies.Stream = function() {
                     self.videoModel.setMute(false);
                 };
 
+            if (speed === trickModeSpeed) {
+                return;
+            }
+
             if (trickModeSpeed === 1 && trickModeEnabled) {
                 self.videoModel.setMute(true);
                 self.videoModel.pause();
                 self.videoModel.listen("seeked", seekedListener);
-            } else if (!trickModeEnabled) {
+            } else if (!trickModeEnabled && self.videoModel.isPaused()) {
                 self.videoModel.play();
             }
 

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -627,9 +627,7 @@ MediaPlayer.dependencies.Stream = function() {
                 delay,
                 _seek = function (delay, seekValue) {
                     if (self.videoModel.getCurrentTime() === self.getStartTime() || tmEndDetected) {
-                        self.videoModel.unlisten("seeked", seekedListener);
-                        self.videoModel.setCurrentTime(0);
-                        tmEndDetected = false;
+                        self.debug.log("[Stream] Trick mode (x" + tmSpeed + "): stop");
                         return;
                     }
                     if (seekValue < self.getStartTime()) {
@@ -1383,15 +1381,15 @@ MediaPlayer.dependencies.Stream = function() {
                 if (!enableTrickMode) {
                     self.debug.info("[Stream] Trick mode: Stopped, current time = " + currentVideoTime);
                     tmState = "Stopped";
-                    //self.videoModel.listen("seeking", seekingListener);
-                    //self.videoModel.unlisten("seeked", seekedListener);
                     self.videoModel.listen("timeupdate", enableMute);
-                    seek.call(self, currentVideoTime, true);
+                    currentVideoTime = tmEndDetected ? self.getStartTime() : currentVideoTime;
+                    seek.call(self, tmEndDetected ? self.getStartTime() : currentVideoTime, true);
                 } else {
                     if (tmState === "Running") {
                         tmState = "Changed";
                     }
                     else if (tmState === "Stopped") {
+                        tmEndDetected = false;
                         tmState = "Running";
                         tmSeekStep = tmMinSeekStep = videoController.getLastDownloadedSegmentDuration();
                         tmStartTime = tmSeekTime = (new Date().getTime()) / 1000;

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -871,7 +871,7 @@ MediaPlayer.dependencies.Stream = function() {
         // => then seek every BufferController at the found start time
         onStartTimeFound = function(startTime) {
             this.debug.info("[Stream] Start time = " + startTime);
-            seek.call(this, 100/*startTime*/, (periodInfo.index === 0) && autoPlay);
+            seek.call(this, startTime, (periodInfo.index === 0) && autoPlay);
         },
 
         // ORANGE: 'bufferUpdated' event raised when some data has been appended into media buffers

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -37,7 +37,6 @@ MediaPlayer.dependencies.Stream = function() {
         textTrackIndex = -1,
         autoPlay = true,
         initialized = false,
-        load,
         errored = false,
 
         // Events listeners
@@ -872,7 +871,7 @@ MediaPlayer.dependencies.Stream = function() {
         // => then seek every BufferController at the found start time
         onStartTimeFound = function(startTime) {
             this.debug.info("[Stream] Start time = " + startTime);
-            seek.call(this, startTime, (periodInfo.index === 0) && autoPlay);
+            seek.call(this, 100/*startTime*/, (periodInfo.index === 0) && autoPlay);
         },
 
         // ORANGE: 'bufferUpdated' event raised when some data has been appended into media buffers
@@ -1076,8 +1075,6 @@ MediaPlayer.dependencies.Stream = function() {
             // Protection event handlers
             this[MediaPlayer.dependencies.ProtectionController.eventList.ENAME_PROTECTION_ERROR] = onProtectionError.bind(this);
             /* @endif */
-
-            load = Q.defer();
 
             playListener = onPlay.bind(this);
             pauseListener = onPause.bind(this);
@@ -1285,7 +1282,6 @@ MediaPlayer.dependencies.Stream = function() {
                     protectionController = undefined;
                     self.fragmentController = undefined;
 
-                    load = Q.defer();
                     deferred.resolve();
                 });
 

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -602,14 +602,14 @@ MediaPlayer.dependencies.Stream = function() {
             var time = this.videoModel.getCurrentTime();
             this.debug.info("[Stream] <video> seeking event: " + time);
 
-            // Check if seek time is less than range start, never seek before range start.
-            time = (time < this.getStartTime()) ? this.getStartTime() : time;
-
             // Check if seeking is different from trick mode seeking, then cancel trick mode
             if ((tmSpeed !== 1) && (time.toFixed(3) !== tmSeekValue.toFixed(3))) {
                 this.setTrickModeSpeed(1);
                 return;
             }
+
+            // Check if seek time is less than range start, never seek before range start.
+            time = (time < this.getStartTime()) ? this.getStartTime() : time;
 
             startBuffering.call(this, time);
         },

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -523,7 +523,7 @@ MediaPlayer.dependencies.Stream = function() {
                 this.setTrickModeSpeed(1);
             } else {
                 // Set the currentTime here to be sure that videoTag is ready to accept the seek (cause IE fail on set currentTime on BufferUpdate)
-                if (playStartTime > 0) {
+                if (playStartTime >= 0) {
                     setVideoModelCurrentTime.call(this, playStartTime);
                     playStartTime = -1;
                 } else {

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -626,14 +626,14 @@ MediaPlayer.dependencies.Stream = function() {
                 seekValue,
                 delay,
                 _seek = function (delay, seekValue) {
-                    if (self.videoModel.getCurrentTime() === 0 || tmEndDetected) {
+                    if (self.videoModel.getCurrentTime() === self.getStartTime() || tmEndDetected) {
                         self.videoModel.unlisten("seeked", seekedListener);
                         self.videoModel.setCurrentTime(0);
                         tmEndDetected = false;
                         return;
                     }
-                    if (seekValue < 0) {
-                        seekValue = 0;
+                    if (seekValue < self.getStartTime()) {
+                        seekValue = self.getStartTime();
                     } else if (seekValue >= self.videoModel.getElement().duration) {
                         seekValue = self.videoModel.getElement().duration - tmMinSeekStep;
                         tmEndDetected = true;

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -26,6 +26,7 @@ MediaPlayer.dependencies.Stream = function() {
         audioTrackIndex = -1,
         textController = null,
         subtitlesEnabled = false,
+        trickModeEnabled = false,
         textTrackIndex = -1,
         autoPlay = true,
         initialized = false,
@@ -1282,6 +1283,25 @@ MediaPlayer.dependencies.Stream = function() {
                     }
                 }
             }
+        },
+
+        setTrickPlay: function(speed){
+            var funcs = [],
+                self = this;
+            trickModeEnabled = speed > 1 ? true : false;
+
+            if(videoController) {
+               funcs.push(videoController.setTrickPlay(speed));
+            }
+            if (audioController) {
+                funcs.push(audioController.setTrickPlay(speed));
+            }
+
+            Q.all(funcs).then(function (){
+                if (!trickModeEnabled) {
+                    seek.call(self, self.videoModel.getCurrentTime());
+                }
+            });
         },
 
         updateData: updateData,

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -106,7 +106,7 @@ MediaPlayer.dependencies.Stream = function() {
 
             this.debug.info("[Stream] Do seek: " + time);
 
-            this.videoModel.pause();
+            //this.videoModel.pause();
             
             // Performs a programmatical seek:
             // 1- seeks the buffer controllers at the desired time
@@ -1311,7 +1311,7 @@ MediaPlayer.dependencies.Stream = function() {
             eventController.reset();
         },
         enableSubtitles: function(enabled) {
-            
+
             if (enabled !== subtitlesEnabled) {
                 subtitlesEnabled = enabled;
                 if (textController) {

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -1285,21 +1285,23 @@ MediaPlayer.dependencies.Stream = function() {
             }
         },
 
-        setTrickPlay: function(speed){
+        setTrickPlay: function(enabled){
             var funcs = [],
                 self = this;
-            trickModeEnabled = speed > 1 ? true : false;
+            trickModeEnabled = enabled;
 
             if(videoController) {
-               funcs.push(videoController.setTrickPlay(speed));
+               funcs.push(videoController.setTrickPlay(enabled));
             }
             if (audioController) {
-                funcs.push(audioController.setTrickPlay(speed));
+                funcs.push(audioController.setTrickPlay(enabled));
             }
 
             Q.all(funcs).then(function (){
                 if (!trickModeEnabled) {
-                    seek.call(self, self.videoModel.getCurrentTime());
+                    var currentTime = self.videoModel.getCurrentTime();
+                    self.debug.info("[Stream] setTrickPlay disabled seek to "+currentTime);
+                    seek.call(self, currentTime);
                 }
             });
         },

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -691,12 +691,11 @@ MediaPlayer.dependencies.Stream = function() {
 
                 _seek.call(self, delay, seekValue);
 
-            } else {
-                // The current time has been changed on video model, then reactivate 'seeking' event listener
-                // (see setVideoModelCurrentTime())
-                this.videoModel.listen("seeking", seekingListener);
-                this.videoModel.unlisten("seeked", seekedListener);
             }
+
+            // The current time has been changed on video model, then reactivate 'seeking' event listener
+            // (see setVideoModelCurrentTime())
+            this.videoModel.listen("seeking", seekingListener);
 
             startClockTime = -1;
             startStreamTime = -1;
@@ -859,7 +858,6 @@ MediaPlayer.dependencies.Stream = function() {
         setVideoModelCurrentTime = function(time) {
             this.debug.log("[Stream] Set video model current time: " + time);
             this.videoModel.unlisten("seeking", seekingListener);
-            this.videoModel.listen("seeked", seekedListener);
             this.videoModel.setCurrentTime(time);
         },
 
@@ -1259,7 +1257,6 @@ MediaPlayer.dependencies.Stream = function() {
             // Trick mode seeking timeout
             clearTimeout(tmSeekTimeout);
 
-            self.videoModel.unlisten("seeked", seekedListener);
             self.videoModel.setMute(false);
 
             //document.removeEventListener("visibilityChange");
@@ -1268,6 +1265,7 @@ MediaPlayer.dependencies.Stream = function() {
             this.videoModel.unlisten("pause", pauseListener);
             this.videoModel.unlisten("error", errorListener);
             this.videoModel.unlisten("seeking", seekingListener);
+            this.videoModel.unlisten("seeked", seekingListener);
             this.videoModel.unlisten("timeupdate", timeupdateListener);
             this.videoModel.unlisten("durationchange", durationchangeListener);
             this.videoModel.unlisten("progress", progressListener);
@@ -1374,7 +1372,6 @@ MediaPlayer.dependencies.Stream = function() {
                 self.debug.info("[Stream] Set mute: true");
                 self.videoModel.setMute(true);
                 self.videoModel.pause();
-                self.videoModel.listen("seeked", seekedListener);
             } else if (!enableTrickMode) {
                 tmSpeed = 1;
                 clearTimeout(tmSeekTimeout);

--- a/app/js/streaming/StreamController.js
+++ b/app/js/streaming/StreamController.js
@@ -673,10 +673,17 @@ MediaPlayer.dependencies.StreamController = function() {
             }
         },
 
-        setTrickModeSpeed: function(speed){
+        setTrickModeSpeed: function(speed) {
             if (activeStream) {
                 activeStream.setTrickModeSpeed(speed);
             }
+        },
+
+        getTrickModeSpeed: function() {
+            if (activeStream) {
+                return activeStream.getTrickModeSpeed();
+            }
+            return 0;
         },
 
         play: play,

--- a/app/js/streaming/StreamController.js
+++ b/app/js/streaming/StreamController.js
@@ -673,9 +673,9 @@ MediaPlayer.dependencies.StreamController = function() {
             }
         },
 
-        setTrickPlay: function(speed){
+        setTrickModeSpeed: function(speed){
             if (activeStream) {
-                activeStream.setTrickPlay(speed);
+                activeStream.setTrickModeSpeed(speed);
             }
         },
 

--- a/app/js/streaming/StreamController.js
+++ b/app/js/streaming/StreamController.js
@@ -419,7 +419,7 @@ MediaPlayer.dependencies.StreamController = function() {
             if (manifest.hasOwnProperty("Location")) {
                 url = manifest.Location;
             }
-
+debugger;
             this.debug.log("### Refresh manifest @ " + url);
             this.refreshManifest(url, true);
         },
@@ -670,6 +670,12 @@ MediaPlayer.dependencies.StreamController = function() {
             subtitlesEnabled = enabled;
             if (activeStream) {
                 activeStream.enableSubtitles(enabled);
+            }
+        },
+
+        setTrickPlay: function(speed){
+            if (activeStream) {
+                activeStream.setTrickPlay(speed);
             }
         },
 

--- a/app/js/streaming/StreamController.js
+++ b/app/js/streaming/StreamController.js
@@ -673,9 +673,9 @@ MediaPlayer.dependencies.StreamController = function() {
             }
         },
 
-        setTrickPlay: function(enabled){
+        setTrickPlay: function(speed){
             if (activeStream) {
-                activeStream.setTrickPlay(enabled);
+                activeStream.setTrickPlay(speed);
             }
         },
 

--- a/app/js/streaming/StreamController.js
+++ b/app/js/streaming/StreamController.js
@@ -673,9 +673,9 @@ MediaPlayer.dependencies.StreamController = function() {
             }
         },
 
-        setTrickPlay: function(speed){
+        setTrickPlay: function(enabled){
             if (activeStream) {
-                activeStream.setTrickPlay(speed);
+                activeStream.setTrickPlay(enabled);
             }
         },
 

--- a/app/js/streaming/StreamController.js
+++ b/app/js/streaming/StreamController.js
@@ -41,20 +41,6 @@ MediaPlayer.dependencies.StreamController = function() {
         defaultSubtitleLang = 'und',
         subtitlesEnabled = false,
 
-        play = function() {
-            activeStream.play();
-        },
-
-        pause = function() {
-            if (activeStream) {
-                activeStream.pause();
-            }
-        },
-
-        seek = function(time) {
-            activeStream.seek(time);
-        },
-
         /*
          * Replaces the currently displayed <video> with a new data and corresponding <video> element.
          *
@@ -686,9 +672,21 @@ MediaPlayer.dependencies.StreamController = function() {
             return 0;
         },
 
-        play: play,
-        seek: seek,
-        pause: pause
+        play: function() {
+            activeStream.play();
+        },
+
+        pause: function() {
+            if (activeStream) {
+                activeStream.pause();
+            }
+        },
+
+        seek: function(time) {
+            if (activeStream) {
+                activeStream.seek(time);
+            }
+        },
     };
 };
 

--- a/app/js/streaming/StreamController.js
+++ b/app/js/streaming/StreamController.js
@@ -419,7 +419,7 @@ MediaPlayer.dependencies.StreamController = function() {
             if (manifest.hasOwnProperty("Location")) {
                 url = manifest.Location;
             }
-debugger;
+
             this.debug.log("### Refresh manifest @ " + url);
             this.refreshManifest(url, true);
         },

--- a/app/js/streaming/VideoModel.js
+++ b/app/js/streaming/VideoModel.js
@@ -58,7 +58,6 @@ MediaPlayer.models.VideoModel = function () {
             return element.paused;
         },
 
-        //ORANGE : add isSeeking function
         isSeeking: function() {
             return element.seeking;
         },
@@ -69,6 +68,14 @@ MediaPlayer.models.VideoModel = function () {
 
         setPlaybackRate: function (value) {
             element.playbackRate = value;
+        },
+
+        getMute:  function () {
+            return element.muted;
+        },
+
+        setMute: function (value) {
+            element.muted = value;
         },
 
         getCurrentTime: function () {

--- a/app/js/streaming/VideoModel.js
+++ b/app/js/streaming/VideoModel.js
@@ -83,14 +83,6 @@ MediaPlayer.models.VideoModel = function () {
         },
 
         setCurrentTime: function (currentTime) {
-            //_currentTime = currentTime;
-
-            // We don't set the same currentTime because it can cause firing unexpected Pause event in IE11
-            // providing playbackRate property equals to zero.
-            if (element.currentTime === currentTime) {
-                return;
-            }
-
             element.currentTime = currentTime;
         },
 

--- a/samples/Dash-IF/index.html
+++ b/samples/Dash-IF/index.html
@@ -480,6 +480,14 @@
                             <button type="button" class="btn btn-default" ng-click="playbackRateUp()"><span class="glyphicon glyphicon-plus"></span></button>
                         </div>
                     </div>
+                    <div class="panel-heading panel-top">
+                        <span class="panel-title">Trick mode: </span>
+                        <span class="text-warning">{{trickModeSpeed}}</span>
+                        <div class="btn-group">
+                            <button type="button" class="btn btn-default" ng-click="trickModeSpeedDown()"><span class="glyphicon glyphicon-minus"></span></button>
+                            <button type="button" class="btn btn-default" ng-click="trickModeSpeedUp()"><span class="glyphicon glyphicon-plus"></span></button>
+                        </div>
+                    </div>
                 </div>
                 <div class="panel">
                     <div class="panel-heading panel-top">

--- a/samples/Dash-IF/js/main.js
+++ b/samples/Dash-IF/js/main.js
@@ -745,7 +745,7 @@ app.controller('DashController', ['$scope', '$window', 'Sources', 'Notes','Contr
             return;
         }
 
-        newSpeed = (currentSpeed === 1) ? -2 : (currentSpeed * 2);
+        newSpeed = (currentSpeed === 1) ? -2 : ((currentSpeed > 1) ? (currentSpeed / 2) : (currentSpeed * 2));
 
         player.setTrickModeSpeed(newSpeed);
         $scope.trickModeSpeed = "x" + newSpeed;

--- a/samples/Dash-IF/js/main.js
+++ b/samples/Dash-IF/js/main.js
@@ -723,6 +723,34 @@ app.controller('DashController', ['$scope', '$window', 'Sources', 'Notes','Contr
         }
     };
 
+    $scope.trickModeSpeedUp = function () {
+        var currentSpeed = player.getTrickModeSpeed(),
+            newSpeed;
+
+        if (currentSpeed === 128.0) {
+            return;
+        }
+
+        newSpeed = (currentSpeed < 0) ? 1 : (currentSpeed * 2);
+
+        player.setTrickModeSpeed(newSpeed);
+        $scope.trickModeSpeed = "x" + newSpeed;
+    };
+
+    $scope.trickModeSpeedDown = function () {
+        var currentSpeed = player.getTrickModeSpeed(),
+            newSpeed;
+
+        if (currentSpeed === -128.0) {
+            return;
+        }
+
+        newSpeed = (currentSpeed === 1) ? -2 : (currentSpeed * 2);
+
+        player.setTrickModeSpeed(newSpeed);
+        $scope.trickModeSpeed = "x" + newSpeed;
+    };
+
     ////////////////////////////////////////
     //
     // Page Setup

--- a/samples/Dash-IF/js/main.js
+++ b/samples/Dash-IF/js/main.js
@@ -367,6 +367,10 @@ app.controller('DashController', ['$scope', '$window', 'Sources', 'Notes','Contr
         }
     }
 
+    function onplay(/*e*/) {
+        $scope.trickModeSpeed = "x1";
+    }
+
     //if video size change, player has to update subtitles size
     function onFullScreenChange(){
         setSubtitlesCSSStyle(subtitlesCSSStyle);
@@ -644,6 +648,7 @@ app.controller('DashController', ['$scope', '$window', 'Sources', 'Notes','Contr
     player.addEventListener("subtitlesStyleChanged",onSubtitlesStyleChanged.bind(this));
     player.addEventListener("manifestUrlUpdate", onManifestUrlUpdate.bind(this));
     video.addEventListener("loadeddata", onload.bind(this));
+    video.addEventListener("play", onplay.bind(this));
     video.addEventListener("fullscreenchange", onFullScreenChange.bind(this));
     video.addEventListener("mozfullscreenchange", onFullScreenChange.bind(this));
     video.addEventListener("webkitfullscreenchange", onFullScreenChange.bind(this));


### PR DESCRIPTION
Add trick mode support.
This mode enables fast forward and fast rewind.
This is achieved by:
- mute audio
- requesting key frames for audio and video segments, at lowest quality (keeping audio fragments is required, otherwise play would stop)
- processing segments and duplicate key frames in order to fill in media segments
- doing successive seeks, delays between successive seeks and seek values are determined according to target trick mode speed and current bandwidth