### PR TITLE
Error if FourCC value is not specified in audio stream

### DIFF
--- a/app/js/mss/MssParser.js
+++ b/app/js/mss/MssParser.js
@@ -144,7 +144,7 @@ Mss.dependencies.MssParser = function() {
             fourCCValue = this.domParser.getAttributeValue(qualityLevel, "FourCC");
 
             if (fourCCValue === null) {
-                fourCCValue = this.domParser.getAttributeValue(streamIndex, "FourCC");
+                fourCCValue = this.domParser.getAttributeValue(streamIndex, "FourCC") || "AAC";     // if FourCC not found consider AAC (suppose we are in audio stream)
             }
             // Do not support AACH (TODO)
             if (fourCCValue.indexOf("AACH") >= 0) {


### PR DESCRIPTION
mssParser gave an error because was trying to access FourCC. Assuming "AAC" if not found.