### PR TITLE
Live delay

### DIFF
--- a/app/js/streaming/BufferExtensions.js
+++ b/app/js/streaming/BufferExtensions.js
@@ -1,14 +1,14 @@
 /*
  * The copyright in this software is being made available under the BSD License, included below. This software may be subject to other third party and contributor rights, including patent rights, and no such rights are granted under this license.
- * 
+ *
  * Copyright (c) 2013, Digital Primates
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
  * •  Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
  * •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
  * •  Neither the name of the Digital Primates nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 MediaPlayer.dependencies.BufferExtensions = function () {
@@ -159,6 +159,7 @@ MediaPlayer.dependencies.BufferExtensions.BUFFER_SIZE_MIN = "min";
 MediaPlayer.dependencies.BufferExtensions.BUFFER_SIZE_INFINITY = "infinity";
 MediaPlayer.dependencies.BufferExtensions.BUFFER_TIME_AT_STARTUP = 1;
 MediaPlayer.dependencies.BufferExtensions.DEFAULT_MIN_BUFFER_TIME = 16;
+MediaPlayer.dependencies.BufferExtensions.DEFAULT_LIVE_DELAY = 16;
 MediaPlayer.dependencies.BufferExtensions.BUFFER_TIME_AT_TOP_QUALITY = 30;
 MediaPlayer.dependencies.BufferExtensions.BUFFER_TIME_AT_TOP_QUALITY_LONG_FORM = 300;
 MediaPlayer.dependencies.BufferExtensions.LONG_FORM_CONTENT_DURATION_THRESHOLD = 600;

--- a/app/js/streaming/Config.js
+++ b/app/js/streaming/Config.js
@@ -23,6 +23,7 @@ MediaPlayer.utils.Config = function () {
             // BufferController parameters
             "BufferController.minBufferTimeForPlaying": -1,
             "BufferController.minBufferTime": -1,
+            "BufferController.liveDelay": -1,
             // ABR parameters
             "ABR.minBandwidth": -1,
             "ABR.maxBandwidth": -1,

--- a/app/js/streaming/MediaPlayer.js
+++ b/app/js/streaming/MediaPlayer.js
@@ -127,7 +127,6 @@ MediaPlayer = function () {
         videoModel.getElement().dispatchEvent(event);
     };
 
-
     var _metricAdded = function (e) {
         var event;
         switch (e.data.metric) {
@@ -246,10 +245,7 @@ MediaPlayer = function () {
         _cleanStreamTab(streamTab, idToRemove);
     };
 
-
-    /**
-     * Usefull to dispatch event of quality changed
-     */
+    // Usefull to dispatch event of quality changed
     var _onTimeupdate = function () {
         // If not in playing state, then do not send 'play_bitrate' events, wait for 'loadeddata' event first
         if (videoModel.getPlaybackRate() === 0) {
@@ -261,9 +257,6 @@ MediaPlayer = function () {
         _detectPlayBitrateChange.call(this, audioQualityChanged);
     };
 
-
-
-
     // event connection
     var _connectEvents = function () {
         this.addEventListener('metricAdded', _metricAdded.bind(this));
@@ -271,8 +264,6 @@ MediaPlayer = function () {
         this.addEventListener('warning', _onWarning.bind(this));
         this.addEventListener('timeupdate', _onTimeupdate.bind(this));
     };
-
-
 
 
     /// Private playback functions ///
@@ -1306,7 +1297,7 @@ MediaPlayer = function () {
         * @method isSubtitlesEnabled
         * @access public
         * @memberof MediaPlayer#
-        * @retrun {boolean} true if subtitles are enabled, false otherwise
+        * @return {boolean} true if subtitles are enabled, false otherwise
        */
         isSubtitlesEnabled: function () {
             _isPlayerInitialized();

--- a/app/js/streaming/MediaPlayer.js
+++ b/app/js/streaming/MediaPlayer.js
@@ -882,7 +882,7 @@ MediaPlayer = function () {
          */
         seek: function (time) {
             var range = null,
-                minBufferTime = 0;
+                liveEdge = 0;
 
             _isPlayerInitialized();
 
@@ -898,15 +898,15 @@ MediaPlayer = function () {
                 }
             } else {
                 range = this.getDVRWindowRange();
-                minBufferTime = streamController.getMinBufferTime();
+                liveEdge = streamController.getLiveEdge();
                 if (range === null) {
                     throw new Error('MediaPlayer.seek(): impossible for live stream');
                 } else if (time < range.start || time > range.end) {
                     throw new Error('MediaPlayer.seek(): seek value outside available time range');
                 } else {
                     // Ensure we keep enough buffer
-                    if (time > (range.end - minBufferTime)) {
-                        time = range.end - minBufferTime;
+                    if (time > (range.end - liveEdge)) {
+                        time = range.end - liveEdge;
                     }
                     streamController.seek(time, true);
                 }

--- a/app/js/streaming/MediaPlayer.js
+++ b/app/js/streaming/MediaPlayer.js
@@ -1676,6 +1676,7 @@ MediaPlayer.TRACKS_TYPE = {
  * @type Object
  * @property {number}   BufferController.minBufferTimeForPlaying - Minimum buffer level before playing, in seconds (default value = 0)
  * @property {number}   BufferController.minBufferTime - Minimum buffer size, in seconds (default value = 16)
+ * @property {number}   BufferController.liveDelay - The delay between the live edge and playing time (default value = minBufferTime)
  * @property {number}   ABR.minBandwidth - Minimum bandwidth to be playbacked (default value = -1)
  * @property {number}   ABR.maxBandwidth - Maximum bandwidth to be playbacked (default value = -1)
  * @property {number}   ABR.minQuality - Minimum quality index (start from 0) to be playbacked (default value = -1)

--- a/app/js/streaming/MediaPlayer.js
+++ b/app/js/streaming/MediaPlayer.js
@@ -570,7 +570,7 @@ MediaPlayer = function () {
          * Sets player configuration parameters.
          * @access public
          * @memberof MediaPlayer#
-         * @param {PlayerParams} params - parameter(s) value(s) to set.
+         * @param {MediaPlayer#PlayerParams} params - parameter(s) value(s) to set.
          */
         setConfig: function (params) {
             if (this.config && params) {
@@ -1672,7 +1672,7 @@ MediaPlayer.TRACKS_TYPE = {
  * Player parameters object.
  * All parameters values are applied for any stream type. Parameters can be overriden specifically for audio and video track by setting
  * parameters values in the params.audio and params.video objects.
- * @typedef PlayerParams
+ * @typedef MediaPlayer#PlayerParams
  * @type Object
  * @property {number}   BufferController.minBufferTimeForPlaying - Minimum buffer level before playing, in seconds (default value = 0)
  * @property {number}   BufferController.minBufferTime - Minimum buffer size, in seconds (default value = 16)

--- a/app/js/streaming/MediaPlayer.js
+++ b/app/js/streaming/MediaPlayer.js
@@ -1676,7 +1676,7 @@ MediaPlayer.TRACKS_TYPE = {
  * @type Object
  * @property {number}   BufferController.minBufferTimeForPlaying - Minimum buffer level before playing, in seconds (default value = 0)
  * @property {number}   BufferController.minBufferTime - Minimum buffer size, in seconds (default value = 16)
- * @property {number}   BufferController.liveDelay - The delay between the live edge and playing time (default value = minBufferTime)
+ * @property {number}   BufferController.liveDelay - The delay between the live edge and playing time, in seconds (default value = minBufferTime)
  * @property {number}   ABR.minBandwidth - Minimum bandwidth to be playbacked (default value = -1)
  * @property {number}   ABR.maxBandwidth - Maximum bandwidth to be playbacked (default value = -1)
  * @property {number}   ABR.minQuality - Minimum quality index (start from 0) to be playbacked (default value = -1)

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -1209,6 +1209,20 @@ MediaPlayer.dependencies.Stream = function() {
             return periodInfo;
         },
 
+        getMinbufferTime: function() {
+            if (!videoController) {
+                return MediaPlayer.dependencies.BufferExtensions.DEFAULT_MIN_BUFFER_TIME;
+            }
+            return videoController.getMinbufferTime();
+        },
+
+        getLivedelay: function() {
+            if (!videoController) {
+                return MediaPlayer.dependencies.BufferExtensions.DEFAULT_LIVE_DELAY;
+            }
+            return videoController.getLivedelay();
+        },
+
         startEventController: function() {
             eventController.start();
         },

--- a/app/js/streaming/StreamController.js
+++ b/app/js/streaming/StreamController.js
@@ -272,7 +272,7 @@ MediaPlayer.dependencies.StreamController = function() {
             }
 
             this.debug.info("[StreamController] composeStreams");
-            
+
             if (self.capabilities.supportsEncryptedMedia()) {
                 if (!protectionController) {
                     protectionController = self.system.getObject("protectionController");
@@ -406,7 +406,7 @@ MediaPlayer.dependencies.StreamController = function() {
             if (deferredLoading) {
                 deferredLoading.resolve();
                 deferredLoading = null;
-            }            
+            }
         };
 
     return {
@@ -497,11 +497,18 @@ MediaPlayer.dependencies.StreamController = function() {
             return undefined;
         },
 
-        getMinBufferTime: function () {
-            if (!this.manifestModel || !this.manifestModel.getValue()) {
-                return -1;
+        getMinbufferTime: function() {
+            if (!activeStream) {
+                return MediaPlayer.dependencies.BufferExtensions.DEFAULT_MIN_BUFFER_TIME;
             }
-            return this.manifestModel.getValue().minBufferTime;
+            return activeStream.getMinbufferTime();
+        },
+
+        getLivedelay: function() {
+            if (!activeStream) {
+                return MediaPlayer.dependencies.BufferExtensions.DEFAULT_LIVE_DELAY;
+            }
+            return activeStream.getLivedelay();
         },
 
         load: function(newSource) {

--- a/samples/Dash-IF/hasplayer_config.json
+++ b/samples/Dash-IF/hasplayer_config.json
@@ -11,6 +11,9 @@
     "// BufferController.minBufferTime": "The minimum media buffer size (in seconds) to fill when playing",
     "BufferController.minBufferTime": -1,
 
+    "// BufferController.liveDelay": "The delay between the live edge and playing time",
+    "BufferController.liveDelay": -1,
+
     "// ABR.minBandwidth" : "The minimum quality bandwidth to be used by ABR controller",
     "ABR.minBandwidth": -1,
 


### PR DESCRIPTION
Add 'BufferController.liveDelay' parameter to control live delay for playback time differently from buffer time (in order to encounter 412-precondition failed issues)