### PR TITLE
Event.srcElement deprecation

### DIFF
--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -469,7 +469,7 @@ MediaPlayer.dependencies.Stream = function() {
         },
 
         onError = function(event) {
-            var error = event.srcElement.error,
+            var error = event.target.error,
                 code,
                 message = "[Stream] <video> error: ";
 


### PR DESCRIPTION
The event.srcElement is a non-standard property and unsupported in Firefox:
https://developer.mozilla.org/en/docs/Web/API/Event/srcElement
This was causing an error on the onError handler in Firefox (access to property error of undefined)