### PR TITLE
EME layer

### DIFF
--- a/app/js/streaming/MediaSourceExtensions.js
+++ b/app/js/streaming/MediaSourceExtensions.js
@@ -42,9 +42,7 @@ MediaPlayer.dependencies.MediaSourceExtensions.prototype = {
 
     detachMediaSource: function (videoModel) {
         "use strict";
-        // it seems that any value passed to the setSource is cast to a string when setting element.src,
-        // so we cannot use null or undefined to reset the element. Use empty string instead.
-        videoModel.setSource("");
+        videoModel.setSource(null);
         return true;
     },
 
@@ -61,7 +59,7 @@ MediaPlayer.dependencies.MediaSourceExtensions.prototype = {
                 break;
             }
         }
-        
+
         if (!updating) {
             source.duration = value;
         }

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -99,7 +99,7 @@ MediaPlayer.dependencies.Stream = function() {
         startStreamTime = -1,
         visibilitychangeListener,
 
-        // Protection errors
+        // ProtectionController events listener
         onProtectionError = function(event) {
             this.errHandler.sendError(event.data.code, event.data.message, event.data.data);
         },
@@ -281,6 +281,53 @@ MediaPlayer.dependencies.Stream = function() {
             return fragmentInfoController;
         },
 
+        initializeProtectionController = function () {
+            var deferred = null,
+                data,
+                audioCodec = null,
+                videoCodec = null,
+                ksSelected,
+                self = this;
+
+            data = this.manifestExt.getVideoData(manifest, periodInfo.index);
+            if (data) {
+                videoCodec = this.manifestExt.getCodec(data);
+                contentProtection = this.manifestExt.getContentProtectionData(data);
+            }
+            data = this.manifestExt.getSpecificAudioData(manifest, periodInfo.index, defaultAudioLang);
+            if (data) {
+                audioCodec = this.manifestExt.getCodec(data);
+            }
+
+            if (!contentProtection) {
+                return Q.when(true);
+            }
+
+            if (!this.capabilities.supportsEncryptedMedia()) {
+                // No protectionController (MediaKeys not supported/enabled) but content is protected => error
+                this.errHandler.sendError(MediaPlayer.dependencies.ErrorHandler.prototype.CAPABILITY_ERR_MEDIAKEYS, "EME is not supported/enabled", null);
+                return Q.when(false);
+            }
+
+            if (!protectionController) {
+                return Q.when(true);
+            }
+
+            deferred = Q.defer();
+
+            ksSelected = {};
+            ksSelected[MediaPlayer.dependencies.ProtectionController.eventList.ENAME_KEY_SYSTEM_SELECTED] = function(event) {
+                self.debug.log("[Stream] ProtectionController initialized");
+                protectionController.unsubscribe(MediaPlayer.dependencies.ProtectionController.eventList.ENAME_KEY_SYSTEM_SELECTED, ksSelected);
+                deferred.resolve(true);
+            };
+            protectionController.subscribe(MediaPlayer.dependencies.ProtectionController.eventList.ENAME_KEY_SYSTEM_SELECTED, ksSelected);
+            this.debug.log("[Stream] Initialize ProtectionController");
+            protectionController.init(contentProtection, audioCodec, videoCodec);
+
+            return deferred.promise;
+        },
+
         initializeMediaSource = function() {
             var data,
                 videoCodec,
@@ -362,14 +409,6 @@ MediaPlayer.dependencies.Stream = function() {
             // Initialize EventController
             if (eventController) {
                 eventController.addInlineEvents(this.manifestExt.getEventsForPeriod(manifest, periodInfo));
-            }
-
-            // Initialize ProtectionController
-            if (protectionController) {
-                protectionController.init(contentProtection, audioCodec, videoCodec);
-            } else if (contentProtection && !this.capabilities.supportsEncryptedMedia()) {
-                // No protectionController (MediaKeys not supported/enabled) but content is protected => error
-                this.errHandler.sendError(MediaPlayer.dependencies.ErrorHandler.prototype.CAPABILITY_ERR_MEDIAKEYS, "EME is not supported/enabled", null);
             }
 
             initializeMediaSourceFinished = true;
@@ -768,17 +807,19 @@ MediaPlayer.dependencies.Stream = function() {
                 return;
             }
 
-            self.debug.log("[Stream] Setup MediaSource");
-            setUpMediaSource.call(self, mediaSource).then(
-                function(mediaSourceResult) {
-                    mediaSource = mediaSourceResult;
-                    self.debug.log("[Stream] Initialize MediaSource");
-                    initializeMediaSource.call(self);
-                    self.debug.log("[Stream] Initialize playback");
-                    initializePlayback.call(self);
-                    self.debug.log("[Stream] Playback initialized");
-                }
-            );
+            initializeProtectionController.call(self).then(function() {
+                self.debug.log("[Stream] Setup MediaSource");
+                setUpMediaSource.call(self, mediaSource).then(
+                    function(mediaSourceResult) {
+                        mediaSource = mediaSourceResult;
+                        self.debug.log("[Stream] Initialize MediaSource");
+                        initializeMediaSource.call(self);
+                        self.debug.log("[Stream] Initialize playback");
+                        initializePlayback.call(self);
+                        self.debug.log("[Stream] Playback initialized");
+                    }
+                );
+            });
         },
 
         setVideoModelCurrentTime = function(time) {

--- a/app/js/streaming/StreamController.js
+++ b/app/js/streaming/StreamController.js
@@ -607,8 +607,6 @@ MediaPlayer.dependencies.StreamController = function() {
             self.manifestUpdater.stop();
             self.parser.reset();
 
-            console.log("[RESET]");
-
             teardownComplete[MediaPlayer.models.ProtectionModel.eventList.ENAME_TEARDOWN_COMPLETE] = function() {
                 // Complete ProtectionController teardown process
                 ownProtectionController = false;
@@ -632,7 +630,6 @@ MediaPlayer.dependencies.StreamController = function() {
                 // Reset the streams
                 for (i = 0; i < streams.length; i += 1) {
                     stream = streams[i];
-                    console.log("[RESET] reset stream");
                     funcs.push(stream.reset());
                     if (stream !== activeStream) {
                         removeVideoElement(stream.getVideoModel().getElement());
@@ -651,7 +648,6 @@ MediaPlayer.dependencies.StreamController = function() {
                         if (!protectionController) {
                             teardownComplete[MediaPlayer.models.ProtectionModel.eventList.ENAME_TEARDOWN_COMPLETE]();
                         } else if (ownProtectionController) {
-                            console.log("[RESET] reset protectionController");
                             protectionController.protectionModel.subscribe(MediaPlayer.models.ProtectionModel.eventList.ENAME_TEARDOWN_COMPLETE, teardownComplete, undefined, true);
                             protectionController.teardown();
                         } else {

--- a/app/js/streaming/VideoModel.js
+++ b/app/js/streaming/VideoModel.js
@@ -132,7 +132,12 @@ MediaPlayer.models.VideoModel = function () {
         },
 
         setSource: function (source) {
-            element.src = source;
+            if (source) {
+                element.src = source;
+            } else {
+                element.removeAttribute('src');
+                element.load();
+            }
         },
 
         isStalled: function () {

--- a/app/js/streaming/protection/CommonEncryption.js
+++ b/app/js/streaming/protection/CommonEncryption.js
@@ -132,95 +132,87 @@ MediaPlayer.dependencies.protection.CommonEncryption = {
         if (data === null)
             return [];
 
-        var buffer = data,
-            done = false,
-            pssh = {},
-            // TODO: Need to check every data read for end of buffer
-            byteCursor = 0,
-            size,
-            nextBox,
-            version,
-            systemID,
-            psshDataSize,
-            boxStart,
-            i,
-            val;
+        var dv = new DataView(data);
+        var done = false;
+        var pssh = {};
 
-        if (!data.buffer) {
-            buffer = new Uint8Array(data);
-        }
-
+        // TODO: Need to check every data read for end of buffer
+        var byteCursor = 0;
         while (!done) {
 
-            boxStart = byteCursor;
+            var size,
+                nextBox,
+                version,
+                systemID,
+                psshDataSize;
+            var boxStart = byteCursor;
 
-            if (byteCursor >= buffer.byteLength)
+            if (byteCursor >= dv.buffer.byteLength)
                 break;
 
             /* Box size */
-            size = this.readBytes(buffer, byteCursor, 4);
+            size = dv.getUint32(byteCursor);
             nextBox = byteCursor + size;
             byteCursor += 4;
 
             /* Verify PSSH */
-            if (this.readBytes(buffer, byteCursor, 4) !== 0x70737368) {
+            if (dv.getUint32(byteCursor) !== 0x70737368) {
                 byteCursor = nextBox;
                 continue;
             }
             byteCursor += 4;
 
             /* Version must be 0 or 1 */
-            version = this.readBytes(buffer, byteCursor, 1);
+            version = dv.getUint8(byteCursor);
             if (version !== 0 && version !== 1) {
                 byteCursor = nextBox;
                 continue;
             }
-            byteCursor += 1;
+            byteCursor++;
 
             byteCursor += 3; /* skip flags */
 
             // 16-byte UUID/SystemID
-            systemID = "";
-
+            systemID = '';
+            var i, val;
             for (i = 0; i < 4; i++) {
-                val = this.readBytes(buffer, (byteCursor + i), 1).toString(16);
-                systemID += (val.length === 1) ? "0" + val : val;
+                val = dv.getUint8(byteCursor + i).toString(16);
+                systemID += (val.length === 1) ? '0' + val : val;
             }
             byteCursor += 4;
-            systemID += "-";
+            systemID += '-';
             for (i = 0; i < 2; i++) {
-                val = this.readBytes(buffer, (byteCursor + i), 1).toString(16);
-                systemID += (val.length === 1) ? "0" + val : val;
+                val = dv.getUint8(byteCursor + i).toString(16);
+                systemID += (val.length === 1) ? '0' + val : val;
             }
             byteCursor += 2;
-            systemID += "-";
+            systemID += '-';
             for (i = 0; i < 2; i++) {
-                val = this.readBytes(buffer, (byteCursor + i), 1).toString(16);
-                systemID += (val.length === 1) ? "0" + val : val;
+                val = dv.getUint8(byteCursor + i).toString(16);
+                systemID += (val.length === 1) ? '0' + val : val;
             }
             byteCursor += 2;
-            systemID += "-";
+            systemID += '-';
             for (i = 0; i < 2; i++) {
-                val = this.readBytes(buffer, (byteCursor + i), 1).toString(16);
-                systemID += (val.length === 1) ? "0" + val : val;
+                val = dv.getUint8(byteCursor + i).toString(16);
+                systemID += (val.length === 1) ? '0' + val : val;
             }
             byteCursor += 2;
-            systemID += "-";
+            systemID += '-';
             for (i = 0; i < 6; i++) {
-                val = this.readBytes(buffer, (byteCursor + i), 1).toString(16);
-                systemID += (val.length === 1) ? "0" + val : val;
+                val = dv.getUint8(byteCursor + i).toString(16);
+                systemID += (val.length === 1) ? '0' + val : val;
             }
             byteCursor += 6;
 
             systemID = systemID.toLowerCase();
 
             /* PSSH Data Size */
-            psshDataSize = this.readBytes(buffer, byteCursor, 4);
+            psshDataSize = dv.getUint32(byteCursor);
             byteCursor += 4;
 
             /* PSSH Data */
-            //pssh[systemID] = buffer.slice(boxStart, nextBox);
-            pssh[systemID] = buffer.subarray(boxStart, nextBox).buffer;
+            pssh[systemID] = dv.buffer.slice(boxStart, nextBox);
             byteCursor = nextBox;
         }
 

--- a/app/js/streaming/protection/ProtectionController.js
+++ b/app/js/streaming/protection/ProtectionController.js
@@ -135,8 +135,10 @@ MediaPlayer.dependencies.ProtectionController = function() {
                         // system and codec information
                         ksAccess = {};
                         ksAccess[MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_SYSTEM_ACCESS_COMPLETE] = function(event) {
+                            self.protectionModel.unsubscribe(MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_SYSTEM_ACCESS_COMPLETE, ksAccess);
                             if (event.error) {
                                 //if (!fromManifest) {
+                                self.debug.log("[DRM] KeySystem Access Denied! -- " + event.error);
                                 self.eventBus.dispatchEvent({
                                     type: MediaPlayer.dependencies.ProtectionController.events.KEY_SYSTEM_SELECTED,
                                     error: "[DRM] KeySystem Access Denied! -- " + event.error
@@ -178,6 +180,10 @@ MediaPlayer.dependencies.ProtectionController = function() {
                 ksSelected = {};
 
                 ksSelected[MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_SYSTEM_ACCESS_COMPLETE] = function(event) {
+                    if (!self.protectionModel) {
+                        return;
+                    }
+                    self.protectionModel.unsubscribe(MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_SYSTEM_ACCESS_COMPLETE, ksSelected);
                     if (event.error) {
                         self.debug.log("[DRM] KeySystem Access Denied!");
                         self.keySystem = undefined;
@@ -197,6 +203,10 @@ MediaPlayer.dependencies.ProtectionController = function() {
                     }
                 };
                 ksSelected[MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_SYSTEM_SELECTED] = function(event) {
+                    if (!self.protectionModel) {
+                        return;
+                    }
+                    self.protectionModel.unsubscribe(MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_SYSTEM_SELECTED, ksSelected);
                     if (!event.error) {
                         self.debug.log("[DRM] KeySystem selected => create key session");
                         self.keySystem = self.protectionModel.keySystem;

--- a/app/js/streaming/protection/ProtectionController.js
+++ b/app/js/streaming/protection/ProtectionController.js
@@ -208,6 +208,7 @@ MediaPlayer.dependencies.ProtectionController = function() {
                     if (!event.error) {
                         self.debug.log("[DRM] KeySystem selected => create key session");
                         self.keySystem = self.protectionModel.keySystem;
+                        self.notify(MediaPlayer.dependencies.ProtectionController.eventList.ENAME_KEY_SYSTEM_SELECTED, keySystemAccess);
                         self.eventBus.dispatchEvent({
                             type: MediaPlayer.dependencies.ProtectionController.events.KEY_SYSTEM_SELECTED,
                             data: keySystemAccess
@@ -939,7 +940,8 @@ MediaPlayer.dependencies.ProtectionController.events = {
 };
 
 MediaPlayer.dependencies.ProtectionController.eventList = {
-    ENAME_PROTECTION_ERROR: "protectionError"
+    ENAME_PROTECTION_ERROR: "protectionError",
+    ENAME_KEY_SYSTEM_SELECTED: "keySystemSelected"
 };
 
 MediaPlayer.dependencies.ProtectionController.prototype = {

--- a/app/js/streaming/protection/ProtectionController.js
+++ b/app/js/streaming/protection/ProtectionController.js
@@ -604,6 +604,8 @@ MediaPlayer.dependencies.ProtectionController = function() {
          * @instance
          */
         teardown: function() {
+            var self = this;
+
             // abort request if xhrLicense is different from null
             if (xhrLicense) {
                 xhrLicense.aborted = true;
@@ -618,11 +620,13 @@ MediaPlayer.dependencies.ProtectionController = function() {
             this.protectionModel.unsubscribe(MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_SESSION_REMOVED, this);
             this.protectionModel.unsubscribe(MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_MESSAGE, this);
             this.protectionModel.unsubscribe(MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_STATUSES_CHANGED, this);
+
             this.keySystem = undefined;
 
-            this.protectionModel.teardown();
-            this.setMediaElement(null);
-            this.protectionModel = undefined;
+            this.setMediaElement(null).then(function() {
+                self.protectionModel.teardown();
+                self.protectionModel = undefined;
+            });
         },
 
         /**
@@ -744,12 +748,11 @@ MediaPlayer.dependencies.ProtectionController = function() {
          */
         setMediaElement: function(element) {
             if (element) {
-                this.protectionModel.setMediaElement(element);
                 this.protectionModel.subscribe(MediaPlayer.models.ProtectionModel.eventList.ENAME_NEED_KEY, this);
             } else if (element === null) {
-                this.protectionModel.setMediaElement(element);
                 this.protectionModel.unsubscribe(MediaPlayer.models.ProtectionModel.eventList.ENAME_NEED_KEY, this);
             }
+            return this.protectionModel.setMediaElement(element);
         },
 
         /**

--- a/app/js/streaming/protection/ProtectionController.js
+++ b/app/js/streaming/protection/ProtectionController.js
@@ -114,8 +114,6 @@ MediaPlayer.dependencies.ProtectionController = function() {
                 ksSelected,
                 keySystemAccess;
 
-            self.debug.log("[DRM] Select key system");
-
             if (this.keySystem) {
                 // We have a key system
                 for (ksIdx = 0; ksIdx < supportedKS.length; ksIdx++) {
@@ -470,7 +468,7 @@ MediaPlayer.dependencies.ProtectionController = function() {
 
         onKeySessionClosed = function(event) {
             if (!event.error) {
-                this.debug.log("[DRM] Session closed.  SessionID = " + event.data);
+                this.debug.log("[DRM] Session closed. SessionID = " + event.data);
             } else {
                 this.debug.warn("[DRM] Failed to close session");
             }
@@ -478,7 +476,7 @@ MediaPlayer.dependencies.ProtectionController = function() {
 
         onKeySessionRemoved = function(event) {
             if (!event.error) {
-                this.debug.log("[DRM] Session removed.  SessionID = " + event.data);
+                this.debug.log("[DRM] Session removed. SessionID = " + event.data);
             } else {
                 this.debug.warn("[DRM] Failed to remove session");
             }
@@ -655,20 +653,18 @@ MediaPlayer.dependencies.ProtectionController = function() {
          */
         createKeySession: function(initData, cdmData) {
 
-            this.debug.log("[DRM] Create key session");
-
             var initDataForKS = MediaPlayer.dependencies.protection.CommonEncryption.getPSSHForKeySystem(this.keySystem, initData),
                 i = 0,
                 currentInitData;
             if (initDataForKS) {
+
+                this.debug.log('[DRM] create key session for initData:', String.fromCharCode.apply(null, new Uint8Array(initDataForKS)));
+
                 // Check for duplicate initData
                 currentInitData = this.protectionModel.getAllInitData();
                 for (i = 0; i < currentInitData.length; i++) {
                     if (this.protectionExt.initDataEquals(initDataForKS, currentInitData[i])) {
                         this.debug.log("[DRM] Ignoring initData because we have already seen it!");
-                        // If Key session already exists for this content, we check if the session and stored license key
-                        // correclty decrypt the content
-                        //this.protectionModel.checkIfEncrypted();
                         return;
                     }
                 }

--- a/app/js/streaming/protection/ProtectionExtensions.js
+++ b/app/js/streaming/protection/ProtectionExtensions.js
@@ -176,8 +176,6 @@ MediaPlayer.dependencies.ProtectionExtensions.prototype = {
     getSupportedKeySystemsFromContentProtection: function(cps) {
         var cp, ks, ksIdx, cpIdx, supportedKS = [];
 
-        this.debug.log("[DRM] Get supported key systems from content protection");
-
         if (cps) {
             for(ksIdx = 0; ksIdx < this.keySystems.length; ++ksIdx) {
                 ks = this.keySystems[ksIdx];
@@ -186,7 +184,7 @@ MediaPlayer.dependencies.ProtectionExtensions.prototype = {
                     if (cp.schemeIdUri.toLowerCase() === ks.schemeIdURI) {
 
                         //this.debug.log("[DRM] Supported key systems: " + ks.systemString + " (" + ks.schemeIdURI + ")");
-                        
+
                         // Look for DRM-specific ContentProtection
                         var initData = ks.getInitData(cp);
                         if (!!initData) {

--- a/app/js/streaming/protection/ProtectionModel_01b.js
+++ b/app/js/streaming/protection/ProtectionModel_01b.js
@@ -350,6 +350,8 @@ MediaPlayer.models.ProtectionModel_01b = function () {
                 videoElement.addEventListener(api.keyadded, eventHandler);
                 this.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_VIDEO_ELEMENT_SELECTED);
             }
+
+            return Q.When();
         },
 
         createKeySession: function(initData /*, keySystemType */) {

--- a/app/js/streaming/protection/ProtectionModel_21Jan2015.js
+++ b/app/js/streaming/protection/ProtectionModel_21Jan2015.js
@@ -357,6 +357,7 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
                 mediaKeys = mkeys;
                 if (videoElement) {
                     videoElement.setMediaKeys(mediaKeys);
+                    videoElement.addEventListener("encrypted", eventHandler);
                 }
                 self.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_SYSTEM_SELECTED);
 

--- a/app/js/streaming/protection/ProtectionModel_21Jan2015.js
+++ b/app/js/streaming/protection/ProtectionModel_21Jan2015.js
@@ -109,6 +109,11 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
                     switch (event.type) {
                         case "encrypted":
                             self.debug.log("[DRM][PM_21Jan2015] 'encrypted' event");
+                            if (event.initData) {
+                                var initData = ArrayBuffer.isView(event.initData) ? event.initData.buffer : event.initData;
+                                self.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_NEED_KEY,
+                                        new MediaPlayer.vo.protection.NeedKey(initData, "cenc"));
+                            }
                             break;
                         case "waitingforkey":
                             self.debug.log("[DRM][PM_21Jan2015] 'waitingforkey' event");

--- a/app/js/streaming/protection/ProtectionModel_21Jan2015.js
+++ b/app/js/streaming/protection/ProtectionModel_21Jan2015.js
@@ -327,12 +327,7 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
         getAllInitData: function() {
             var retVal = [];
             for (var i = 0; i < sessions.length; i++) {
-                if (sessions[i].usable) {
-                    retVal.push(sessions[i].initData);
-                } else {
-                    sessions.splice(i, 1);
-                    i--;
-                }
+                retVal.push(sessions[i].initData);
             }
             return retVal;
         },

--- a/app/js/streaming/protection/ProtectionModel_21Jan2015.js
+++ b/app/js/streaming/protection/ProtectionModel_21Jan2015.js
@@ -135,7 +135,7 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
             // Remove from our session list
             for (var i = 0; i < sessions.length; i++) {
                 if (sessions[i] === token) {
-                    sessions.splice(i,1);
+                    sessions.splice(i, 1);
                     break;
                 }
             }
@@ -144,7 +144,6 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
         // Function to create our session token objects which manage the EME
         // MediaKeySession and session-specific event handler
         createSessionToken = function(session, initData, sessionType) {
-
             var self = this,
                 setSessionUsable = function (session, usable) {
                     for (var i = 0; i < sessions.length; i++) {
@@ -346,6 +345,7 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
 
             self.debug.log("[DRM][PM_21Jan2015] Select key system, create new MediaKeys");
 
+            // In case of license persistence we do not reset MediaKeys instance
             if (mediaKeys !== null) {
                 self.debug.log("[DRM][PM_21Jan2015] MediaKeys already created");
                 self.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_SYSTEM_SELECTED);
@@ -425,6 +425,7 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
             }
 
             this.debug.log("[DRM][PM_21Jan2015] Create key session, type = " + sessionType);
+            this.debug.log("[DRM][PM_21Jan2015] initData = " + String.fromCharCode.apply(null, new Uint8Array(initData)));
 
             var session = mediaKeys.createSession(sessionType);
             var sessionToken = createSessionToken.call(this, session, initData, sessionType);
@@ -449,7 +450,7 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
             // Send our request to the key session
             var self = this;
 
-            self.debug.log("[DRM][PM_21Jan2015] Update key session " + session.sessionId);
+            self.debug.log("[DRM][PM_21Jan2015] Update key session. SessionID = " + session.sessionId);
 
             if (this.protectionExt.isClearKey(this.keySystem)) {
                 message = message.toJWK();
@@ -469,7 +470,7 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
                 throw new Error("Can not load sessions until you have selected a key system");
             }
 
-            this.debug.log("[DRM][PM_21Jan2015] Load key session, id = " + sessionID);
+            this.debug.log("[DRM][PM_21Jan2015] Load key session. SessionID = " + sessionID);
 
             var session = mediaKeys.createSession();
 
@@ -497,21 +498,21 @@ MediaPlayer.models.ProtectionModel_21Jan2015 = function () {
 
             var session = sessionToken.session;
 
-            this.debug.log("[DRM][PM_21Jan2015] Remove key session");
+            this.debug.log("[DRM][PM_21Jan2015] Remove key session. SessionID = " + sessionToken.getSessionID());
 
             var self = this;
             session.remove().then(function () {
                 self.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_SESSION_REMOVED,
-                        sessionToken.getSessionID());
+                    sessionToken.getSessionID());
             }, function (error) {
                 self.notify(MediaPlayer.models.ProtectionModel.eventList.ENAME_KEY_SESSION_REMOVED,
-                        null, "Error removing session (" + sessionToken.getSessionID() + "). " + error.name);
+                    null, "Error removing session (" + sessionToken.getSessionID() + "). " + error.name);
             });
         },
 
         closeKeySession: function(sessionToken) {
 
-            this.debug.log("[DRM][PM_21Jan2015] Close key session");
+            this.debug.log("[DRM][PM_21Jan2015] Close key session. SessionID = " + sessionToken.getSessionID());
 
             // Send our request to the key session
             var self = this;

--- a/app/js/streaming/protection/ProtectionModel_3Feb2014.js
+++ b/app/js/streaming/protection/ProtectionModel_3Feb2014.js
@@ -329,6 +329,8 @@ MediaPlayer.models.ProtectionModel_3Feb2014 = function () {
                     setMediaKeys.call(this);
                 }
             }
+
+            return Q.when();
         },
 
         createKeySession: function(initData, sessionType, cdmData) {


### PR DESCRIPTION
Revisit EME layer (ProtectionModel_21Jan2015) in order to be compliant with both Chrome and Firefox browsers in case we want to re-create a MediaKeys instance when loading a new stream (i.e. in case license persistence is disabled at js application level)