### PR TITLE
Add BufferToKeep parameter

### DIFF
--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -48,6 +48,7 @@ MediaPlayer.dependencies.BufferController = function() {
         buffer = null,
         minBufferTime,
         minBufferTimeAtStartup,
+        bufferToKeep,
         liveDelay,
         bufferTimeout,
         bufferStateTimeout,
@@ -452,12 +453,11 @@ MediaPlayer.dependencies.BufferController = function() {
 
                             isQuotaExceeded = false;
 
-                            // Patch for Safari: do not remove past buffer in live use case
-                            // since it generates MEDIA_ERROR_DECODE while appending new segment
-                            if (isDynamic && bufferLevel > 1 && !isSafari) {
-                                // In case of live streams, remove outdated buffer parts and requests
+                            // Patch for Safari: do not remove past buffer since it generates MEDIA_ERROR_DECODE while appending new segment
+                            if (bufferLevel > 1 && !isSafari) {
+                                // Remove outdated buffer parts and requests
                                 // (checking bufferLevel ensure buffer is not empty or back to current time)
-                                removeBuffer.call(self, -1, getWorkingTime.call(self) - 30).then(
+                                removeBuffer.call(self, -1, getWorkingTime.call(self) - bufferToKeep).then(
                                     function() {
                                         debugBufferRange.call(self);
                                         deferred.resolve();
@@ -1309,6 +1309,7 @@ MediaPlayer.dependencies.BufferController = function() {
             this.setEventController(eventController);
             minBufferTime = this.config.getParamFor(type, "BufferController.minBufferTime", "number", -1);
             minBufferTimeAtStartup = this.config.getParamFor(type, "BufferController.minBufferTimeForPlaying", "number", 0);
+            bufferToKeep = this.config.getParamFor(type, "BufferController.bufferToKeep", "number", MediaPlayer.dependencies.BufferExtensions.DEFAULT_MIN_BUFFER_TIME);
             liveDelay = this.config.getParamFor(type, "BufferController.liveDelay", "number", -1);
 
             this.updateData(newData, newPeriodInfo);

--- a/app/js/streaming/BufferExtensions.js
+++ b/app/js/streaming/BufferExtensions.js
@@ -159,6 +159,7 @@ MediaPlayer.dependencies.BufferExtensions.BUFFER_SIZE_MIN = "min";
 MediaPlayer.dependencies.BufferExtensions.BUFFER_SIZE_INFINITY = "infinity";
 MediaPlayer.dependencies.BufferExtensions.BUFFER_TIME_AT_STARTUP = 1;
 MediaPlayer.dependencies.BufferExtensions.DEFAULT_MIN_BUFFER_TIME = 16;
+MediaPlayer.dependencies.BufferExtensions.DEFAULT_BUFFER_TO_KEEP = 30;
 MediaPlayer.dependencies.BufferExtensions.DEFAULT_LIVE_DELAY = 16;
 MediaPlayer.dependencies.BufferExtensions.BUFFER_TIME_AT_TOP_QUALITY = 30;
 MediaPlayer.dependencies.BufferExtensions.BUFFER_TIME_AT_TOP_QUALITY_LONG_FORM = 300;

--- a/app/js/streaming/Config.js
+++ b/app/js/streaming/Config.js
@@ -23,6 +23,7 @@ MediaPlayer.utils.Config = function () {
             // BufferController parameters
             "BufferController.minBufferTimeForPlaying": -1,
             "BufferController.minBufferTime": -1,
+            "BufferController.bufferToKeep": -1,
             "BufferController.liveDelay": -1,
             // ABR parameters
             "ABR.minBandwidth": -1,

--- a/app/js/streaming/MediaPlayer.js
+++ b/app/js/streaming/MediaPlayer.js
@@ -1698,6 +1698,7 @@ MediaPlayer.TRACKS_TYPE = {
  * @type Object
  * @property {number}   BufferController.minBufferTimeForPlaying - Minimum buffer level before playing, in seconds (default value = 0)
  * @property {number}   BufferController.minBufferTime - Minimum buffer size (in seconds), if set to '-1' the maximum value between the manifest's minBufferTime and 16 sec. is considered (default value = -1)
+ * @property {number}   BufferController.bufferToKeep - The buffer size (in seconds) to keep anterior to current playing time (default value = 30)
  * @property {number}   BufferController.liveDelay - The delay (in seconds) between the live edge and playing time, if set to '-1' the live delay is set according to minBufferTime (default value = -1)
  * @property {number}   ABR.minBandwidth - Minimum bandwidth to be playbacked (default value = -1)
  * @property {number}   ABR.maxBandwidth - Maximum bandwidth to be playbacked (default value = -1)


### PR DESCRIPTION
BufferToKeep parameter is used to set past buffer length to keep, either for static and dynamic streams.
Removing past buffer also for static streams resolves a QutoExceededError issue on Firefoxe.