### PR TITLE
Handling of very large offsets in MSS Manifest (>Number.MAX_SAFE_INTEGER)

### DIFF
--- a/app/js/dash/DashHandler.js
+++ b/app/js/dash/DashHandler.js
@@ -284,7 +284,7 @@ Dash.dependencies.DashHandler = function() {
                     template.media,
                     s.mediaRange,
                     availabilityIdx,
-                    s.tManifest);
+                    s.tManifest_asString);
             };
 
             fTimescale = representation.timescale;
@@ -555,7 +555,7 @@ Dash.dependencies.DashHandler = function() {
             return deferred.promise;
         },
 
-        getTimeBasedSegment = function(representation, time, duration, fTimescale, url, range, index, tManifest) {
+        getTimeBasedSegment = function(representation, time, duration, fTimescale, url, range, index, tManifest_asString) {
             var self = this,
                 scaledTime = time / fTimescale,
                 scaledDuration = Math.min(duration / fTimescale, representation.adaptation.period.mpd.maxSegmentDuration),
@@ -583,7 +583,7 @@ Dash.dependencies.DashHandler = function() {
             // at this wall clock time, the video element currentTime should be seg.presentationStartTime
             seg.wallStartTime = self.timelineConverter.calcWallTimeForSegment(seg, isDynamic);
 
-            seg.replacementTime = tManifest ? tManifest : time;
+            seg.replacementTime = tManifest_asString ? tManifest_asString : time;
 
             seg.replacementNumber = getNumberForSegment(seg, index);
 


### PR DESCRIPTION
We are using live (and post-live VOD with offset) Manifests that have offset exceeding javascript Number.MAX_SAFE_INTEGER. It is the epoch time in microseconds. Because of this hasplayer is calculating the fragment with arithmetic error (e.g. 14942357270000000 + 20053333 = 14942357290053332 instead of 14942357290053333 - precision is lost). 

This fixes the problem using goog.math.Long library and passing tManifest as string instead of a number. 

