### PR TITLE
Fix/mss handling different audio video offsets

### DIFF
--- a/app/js/dash/DashHandler.js
+++ b/app/js/dash/DashHandler.js
@@ -284,7 +284,7 @@ Dash.dependencies.DashHandler = function() {
                     template.media,
                     s.mediaRange,
                     availabilityIdx,
-                    s.tManifest_asString);
+                    s.tManifest);
             };
 
             fTimescale = representation.timescale;
@@ -555,7 +555,7 @@ Dash.dependencies.DashHandler = function() {
             return deferred.promise;
         },
 
-        getTimeBasedSegment = function(representation, time, duration, fTimescale, url, range, index, tManifest_asString) {
+        getTimeBasedSegment = function(representation, time, duration, fTimescale, url, range, index, tManifest) {
             var self = this,
                 scaledTime = time / fTimescale,
                 scaledDuration = Math.min(duration / fTimescale, representation.adaptation.period.mpd.maxSegmentDuration),
@@ -583,7 +583,7 @@ Dash.dependencies.DashHandler = function() {
             // at this wall clock time, the video element currentTime should be seg.presentationStartTime
             seg.wallStartTime = self.timelineConverter.calcWallTimeForSegment(seg, isDynamic);
 
-            seg.replacementTime = tManifest_asString ? tManifest_asString : time;
+            seg.replacementTime = tManifest ? tManifest : time;
 
             seg.replacementNumber = getNumberForSegment(seg, index);
 

--- a/app/js/dash/DashHandler.js
+++ b/app/js/dash/DashHandler.js
@@ -284,7 +284,7 @@ Dash.dependencies.DashHandler = function() {
                     template.media,
                     s.mediaRange,
                     availabilityIdx,
-                    s.tManifest);
+                    s.tManifest_asString);
             };
 
             fTimescale = representation.timescale;
@@ -555,7 +555,7 @@ Dash.dependencies.DashHandler = function() {
             return deferred.promise;
         },
 
-        getTimeBasedSegment = function(representation, time, duration, fTimescale, url, range, index, tManifest) {
+        getTimeBasedSegment = function(representation, time, duration, fTimescale, url, range, index, tManifest_asString) {
             var self = this,
                 scaledTime = time / fTimescale,
                 scaledDuration = Math.min(duration / fTimescale, representation.adaptation.period.mpd.maxSegmentDuration),
@@ -583,7 +583,7 @@ Dash.dependencies.DashHandler = function() {
             // at this wall clock time, the video element currentTime should be seg.presentationStartTime
             seg.wallStartTime = self.timelineConverter.calcWallTimeForSegment(seg, isDynamic);
 
-            seg.replacementTime = tManifest ? tManifest : time;
+            seg.replacementTime = tManifest_asString ? tManifest_asString : time;
 
             seg.replacementNumber = getNumberForSegment(seg, index);
 

--- a/app/js/mss/MssParser.js
+++ b/app/js/mss/MssParser.js
@@ -568,7 +568,7 @@ Mss.dependencies.MssParser = function() {
                         segments = adaptations[i].SegmentTemplate.SegmentTimeline.S_asArray;
                         startTime = segments[0].t;
                         if (startTime > 0) {
-                            timestampOffset = timestampOffset ? Math.min(timestampOffset, startTime) : startTime;
+                            timestampOffset = timestampOffset ? Math.max(timestampOffset, startTime) : startTime;
                         }
                         // Correct content duration according to minimum adaptation's segments duration
                         // in order to force <video> element sending 'ended' event

--- a/app/js/mss/MssParser.js
+++ b/app/js/mss/MssParser.js
@@ -281,19 +281,18 @@ Mss.dependencies.MssParser = function() {
                 chunks = this.domParser.getChildNodes(streamIndex, "c"),
                 segments = [],
                 i,
-                t, d, tManifest_asString;
+                t, d;
 
             for (i = 0; i < chunks.length; i++) {
                 // Get time and duration attributes
-                tManifest_asString = this.domParser.getAttributeValue(chunks[i], "t");
-                t = parseFloat(tManifest_asString);
+                t = parseFloat(this.domParser.getAttributeValue(chunks[i], "t"));
                 d = parseFloat(this.domParser.getAttributeValue(chunks[i], "d"));
 
                 if ((i === 0) && !t) {
                     t = 0;
                 }
 
-               if (i > 0) {
+                if (i > 0) {
                     // Update previous segment duration if not defined
                     if (!segments[segments.length - 1].d) {
                         segments[segments.length - 1].d = t - segments[segments.length - 1].t;
@@ -301,23 +300,12 @@ Mss.dependencies.MssParser = function() {
                     // Set segment absolute timestamp if not set
                     if (!t) {
                         t = segments[segments.length - 1].t + segments[segments.length - 1].d;
-                        tManifest_asString = (parseFloat(segments[segments.length - 1].tManifest_asString) + segments[segments.length - 1].d)+"";
-                        // To handle very large offsets in Manifest (>Number.MAX_SAFE_INTEGER)
-                        if(tManifest_asString.length > 15 ) {//max number is 16 digits (9007199254740991) so this is possible to be over (Number.isSafeInteger is not supported on IE)
-                            var t_asLong = goog.math.Long.fromString(segments[segments.length - 1].tManifest_asString);
-                            var d_asLong = goog.math.Long.fromNumber(segments[segments.length - 1].d);
-                            t_asLong = t_asLong.add(d_asLong);
-                            tManifest_asString = t_asLong.toString();
-                            this.debug.log("Large offest detected as string: "+tManifest_asString+" as number: "+t);
-                            t = t_asLong.toNumber();
-                        }
                     }
                 }
 
                 // Create new segment
                 segments.push({
                     d: d,
-                    tManifest_asString: tManifest_asString,
                     t: t
                 });
 
@@ -578,11 +566,10 @@ Mss.dependencies.MssParser = function() {
 
                 // Patch segment templates timestamps and determine period start time (since audio/video should not be aligned to 0)
                 if (timestampOffset > 0) {
-                    this.debug.log("timestampOffset: "+timestampOffset);
                     for (i = 0; i < adaptations.length; i++) {
                         segments = adaptations[i].SegmentTemplate.SegmentTimeline.S_asArray;
                         for (j = 0; j < segments.length; j++) {
-                            segments[j].tManifest = segments[j].tManifest_asString;
+                            segments[j].tManifest = segments[j].t;
                             segments[j].t -= timestampOffset;
                         }
                         if (adaptations[i].contentType === 'audio' || adaptations[i].contentType === 'video') {


### PR DESCRIPTION
Fixes a potential bug in handling different audio and video stream offsets like:

audio t="14955293986266666"
video t="14955293990000000"
In that case audio 3,7 sec after video.
Without that change player is buffering endlessly in our case.