### PR TITLE
minBufferTime for live MSS

### DIFF
--- a/app/js/streaming/BufferExtensions.js
+++ b/app/js/streaming/BufferExtensions.js
@@ -79,8 +79,9 @@ MediaPlayer.dependencies.BufferExtensions = function () {
         },
 
         decideBufferLength: function (minBufferTime, duration/*, waitingForBuffer*/) {
-            if (isNaN(duration) || MediaPlayer.dependencies.BufferExtensions.DEFAULT_MIN_BUFFER_TIME < duration && minBufferTime < duration) {
-                minBufferTarget = Math.max(MediaPlayer.dependencies.BufferExtensions.DEFAULT_MIN_BUFFER_TIME, minBufferTime);
+
+            if (duration === Infinity) {
+                minBufferTarget = (minBufferTime > 0) ? minBufferTime : MediaPlayer.dependencies.BufferExtensions.DEFAULT_MIN_BUFFER_TIME;
             } else if (minBufferTime >= duration) {
                 minBufferTarget = Math.min(duration, MediaPlayer.dependencies.BufferExtensions.DEFAULT_MIN_BUFFER_TIME);
             } else {


### PR DESCRIPTION
This PR updates timeShiftBufferDepth and then minBufferTime if the segment timeline in the MSS manifest has a duration inferior to manifest's DVRWindowLength value