### PR TITLE
Missing tfrf

### DIFF
--- a/app/js/mss/MssFragmentController.js
+++ b/app/js/mss/MssFragmentController.js
@@ -145,7 +145,15 @@ Mss.dependencies.MssFragmentController = function() {
             }
             // Process tfrf box
             tfrf = traf.getBoxesByType("tfrf");
-            if (tfrf.length !== 0) {
+            if (tfrf === null || tfrf.length === 0) {
+                throw {
+                    name: MediaPlayer.dependencies.ErrorHandler.prototype.MSS_NO_TFRF,
+                    message: 'Missing tfrf in live FragmentInfo segment',
+                    data: {
+                        url: request.url
+                    }
+                };
+            } else {
                 for (i = 0; i < tfrf.length; i += 1) {
                     processTfrf.call(this, request, tfrf[i], tfdt, adaptation);
                 }
@@ -313,11 +321,21 @@ Mss.dependencies.MssFragmentController = function() {
             }
 
             // Process tfrf box
-            tfrf = traf.getBoxesByType("tfrf");
-            if (tfrf.length !== 0) {
-                for (i = 0; i < tfrf.length; i += 1) {
-                    processTfrf.call(this, request, tfrf[i], tfdt, adaptation);
-                    traf.removeBoxByType("tfrf");
+            if (manifest.type === 'dynamic')  {
+                tfrf = traf.getBoxesByType("tfrf");
+                if (tfrf === null || tfrf.length === 0) {
+                    throw {
+                        name: MediaPlayer.dependencies.ErrorHandler.prototype.MSS_NO_TFRF,
+                        message: 'Missing tfrf in live media segment',
+                        data: {
+                            url: request.url
+                        }
+                    };
+                } else {
+                    for (i = 0; i < tfrf.length; i += 1) {
+                        processTfrf.call(this, request, tfrf[i], tfdt, adaptation);
+                        traf.removeBoxByType("tfrf");
+                    }
                 }
             }
 

--- a/app/js/streaming/ErrorHandler.js
+++ b/app/js/streaming/ErrorHandler.js
@@ -73,6 +73,9 @@ MediaPlayer.dependencies.ErrorHandler.prototype.DOWNLOAD_ERR_INIT = "DOWNLOAD_ER
 MediaPlayer.dependencies.ErrorHandler.prototype.DOWNLOAD_ERR_CONTENT = "DOWNLOAD_ERR_CONTENT";
 MediaPlayer.dependencies.ErrorHandler.prototype.CC_ERR_PARSE = "CC_ERR_PARSE";
 
+// MSS errors
+MediaPlayer.dependencies.ErrorHandler.prototype.MSS_NO_TFRF = "MSS_NO_TFRF";
+
 // HLS errors
 MediaPlayer.dependencies.ErrorHandler.prototype.HLS_INVALID_PACKET_ERROR = "HLS_INVALID_PACKET_ERROR";
 MediaPlayer.dependencies.ErrorHandler.prototype.HLS_DEMUX_ERROR = "HLS_DEMUX_ERROR";


### PR DESCRIPTION
Raise an error in case of missing or empty tfrf box in case of live streams.
This can happen if live source is interrupted (see issue #161)