### PR TITLE
Set robustness level for Widevine

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ In the case of protected content, here is an example illustrating setting of the
                         com.microsoft.playready: {
                             laURL: "<licenser_url>",
                             cdmData: "<specific_CDM_data>"
+                            withCredentials: "<license_request_withCredentials_value>",
+                            cdmData: "<CDM_specific_data>", // Only supported by PlayReady key system (using MS-prefixed EME API)
+                            serverCertificate: "<license_server_certificate (as Base64 string)>" // Only supported by Widevine key system
+                            audioRobustness: "<audio_robustness_level>" // Only supported by Widevine key system
+                            videoRobustness: "<video_robustness_level>" // Only supported by Widevine key system
                         }
                     }
                 };

--- a/app/js/streaming/protection/drm/KeySystem_Widevine.js
+++ b/app/js/streaming/protection/drm/KeySystem_Widevine.js
@@ -88,6 +88,19 @@ MediaPlayer.dependencies.protection.KeySystem_Widevine = function() {
             return pssh;
         },
 
+        doGetKeySystemConfigurations = function(videoCodec, audioCodec, sessionType) {
+            var ksConfigurations = MediaPlayer.dependencies.protection.CommonEncryption.getKeySystemConfigurations(videoCodec, audioCodec, sessionType);
+            if (protData) {
+                if (protData.audioRobustness) {
+                    ksConfigurations[0].audioCapabilities[0].robustness = protData.audioRobustness;
+                }
+                if (protData.videoRobustness) {
+                    ksConfigurations[0].videoCapabilities[0].robustness = protData.videoRobustness;
+                }
+            }
+            return ksConfigurations;
+        },
+
         doGetServerCertificate = function() {
             if (protData && protData.serverCertificate && protData.serverCertificate.length > 0) {
                 return BASE64.decodeArray(protData.serverCertificate).buffer;
@@ -113,7 +126,7 @@ MediaPlayer.dependencies.protection.KeySystem_Widevine = function() {
 
         getInitData: doGetInitData,
 
-        getKeySystemConfigurations: MediaPlayer.dependencies.protection.CommonEncryption.getKeySystemConfigurations,
+        getKeySystemConfigurations: doGetKeySystemConfigurations,
 
         getRequestHeadersFromMessage: function(/*message*/) { return null; },
 


### PR DESCRIPTION
This PR enables setting the audio/video robustness levels in protectionData set for Widevine key system.