### PR TITLE
HLS native support

### DIFF
--- a/app/js/hls/HlsStream.js
+++ b/app/js/hls/HlsStream.js
@@ -1,0 +1,688 @@
+/*
+ * The copyright in this software is being made available under the BSD License, included below. This software may be subject to other third party and contributor rights, including patent rights, and no such rights are granted under this license.
+ *
+ * Copyright (c) 2013, Digital Primates
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ * •  Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ * •  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ * •  Neither the name of the Digital Primates nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+Hls.dependencies.HlsStream = function() {
+    "use strict";
+
+    var subtitlesEnabled = false,
+        autoPlay = true,
+        initialized = false,
+        errored = false,
+
+        protectionData,
+        licenseRequest = null,
+
+        // Events listeners
+        endedListener,
+        loadedListener,
+        loadeddataListener,
+        playListener,
+        pauseListener,
+        errorListener,
+        seekingListener,
+        seekedListener,
+        timeupdateListener,
+        durationchangeListener,
+        progressListener,
+        ratechangeListener,
+        canplayListener,
+        playingListener,
+        loadstartListener,
+
+        needKeyListener,
+        keyMessageListener,
+        keyAddedListener,
+        keyErrorListener,
+
+        // Audio/text languages
+        defaultAudioLang = 'und',
+        defaultSubtitleLang = 'und',
+
+        // Initial start time
+        initialStartTime = -1,
+
+        play = function() {
+            if (!initialized) {
+                return;
+            }
+
+            this.debug.info("[Stream] Play.");
+            this.videoModel.play();
+        },
+
+        pause = function() {
+            this.debug.info("[Stream] Pause.");
+            this.videoModel.pause();
+        },
+
+        seek = function(time/*, autoplay*/) {
+            if (!initialized) {
+                //this.debug.info("[Stream] (seek) not initialized");
+                return;
+            }
+
+            this.debug.info("[Stream] Seek: " + time);
+
+            this.videoModel.setCurrentTime(time);
+        },
+
+        onLoaded = function() {
+            this.debug.info("[Stream] <video> loadedmetadata event");
+        },
+
+        onLoadedData = function() {
+            this.debug.info("[Stream] <video> loadeddata event");
+            this.setAudioLang(defaultAudioLang);
+            this.enableSubtitles(subtitlesEnabled);
+        },
+
+        onCanPlay = function() {
+            this.debug.info("[Stream] <video> canplay event");
+            if (autoPlay) {
+                this.videoModel.play();
+            }
+        },
+
+        onPlaying = function() {
+            this.debug.info("[Stream] <video> playing event");
+        },
+
+        onLoadStart = function() {
+            this.debug.info("[Stream] <video> loadstart event");
+        },
+
+        onPlay = function() {
+            this.debug.info("[Stream] <video> play event");
+
+            this.metricsModel.addPlayList("video", new Date().getTime(), this.videoModel.getCurrentTime(), "play");
+        },
+
+        onEnded = function() {
+            this.debug.info("[Stream] <video> ended event");
+            //add stopped state metric with reason = 1 : end of stream
+            this.metricsModel.addState("video", "stopped", this.videoModel.getCurrentTime(), 1);
+        },
+
+        onPause = function() {
+            this.debug.info("[Stream] <video> pause event");
+            this.metricsModel.addPlayList("video", new Date().getTime(), this.videoModel.getCurrentTime(), "pause");
+        },
+
+        onError = function(event) {
+            var error = event.target.error,
+                code,
+                message = "[Stream] <video> error: ";
+
+            if (error.code === -1) {
+                // not an error!
+                return;
+            }
+
+            switch (error.code) {
+                case 1:
+                    code = MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_ERR_ABORTED;
+                    message += "[HLS] The fetching process for the media resource was aborted by the user";
+                    break;
+                case 2:
+                    code = MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_ERR_NETWORK;
+                    message += "[HLS] A network error has caused the user agent to stop fetching the media resource";
+                    break;
+                case 3:
+                    code = MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_ERR_DECODE;
+                    message += "[HLS] An error has occurred in the decoding of the media resource";
+                    break;
+                case 4:
+                    code = MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_ERR_SRC_NOT_SUPPORTED;
+                    message += "[HLS] The media could not be loaded, either because the server or network failed or because the format is not supported";
+                    break;
+                case 5:
+                    code = MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_ERR_ENCRYPTED;
+                    message += "[HLS] The encrypted media stream could not be played";
+                    break;
+            }
+
+            errored = true;
+
+            this.errHandler.sendError(code, message);
+        },
+
+        onSeeking = function() {
+            this.debug.info("[Stream] <video> seeking event: " + this.videoModel.getCurrentTime());
+            this.metricsModel.addState("video", "seeking", this.videoModel.getCurrentTime());
+        },
+
+        onSeeked = function() {
+            // this.debug.info("[Stream] <video> seeked event");
+        },
+
+        onProgress = function() {
+            // this.debug.info("[Stream] <video> progress event");
+        },
+
+        onTimeupdate = function() {
+            this.debug.info("[Stream] <video> timeupdate event: " + this.videoModel.getCurrentTime());
+        },
+
+        onDurationchange = function() {
+            this.debug.info("[Stream] <video> durationchange event: " + this.videoModel.getDuration());
+        },
+
+        onRatechange = function() {
+            this.debug.info("[Stream] <video> ratechange event: " + this.videoModel.getPlaybackRate());
+        },
+
+        stringToArray = function (string) {
+            var buffer = new ArrayBuffer(string.length * 2); // 2 bytes for each char
+            var array = new Uint16Array(buffer);
+            for (var i = 0; i < string.length; i++) {
+                array[i] = string.charCodeAt(i);
+            }
+            return array;
+        },
+
+        extractContentId = function (initData) {
+            var contentId = String.fromCharCode.apply(null, new Uint16Array(initData.buffer));
+
+            var parts = contentId.split("//");
+            if (parts.length != 2) {
+              throw "Invalid content key format";
+            }
+
+            return parts[1];
+        },
+
+        getCertificate = function () {
+            if (protectionData && protectionData.serverCertificate) {
+                return BASE64.decodeArray(protectionData.serverCertificate).buffer;
+            }
+            return [];
+        },
+
+        concatInitDataIdAndCertificate = function (initData, id, cert) {
+            if (typeof id == "string")
+                id = stringToArray(id);
+
+            // layout is [initData][4 byte: idLength][idLength byte: id][4 byte:certLength][certLength byte: cert]
+            var offset = 0;
+            var buffer = new ArrayBuffer(initData.byteLength + 4 + id.byteLength + 4 + cert.byteLength);
+            var dataView = new DataView(buffer);
+
+            var initDataArray = new Uint8Array(buffer, offset, initData.byteLength);
+            initDataArray.set(initData);
+            offset += initDataArray.byteLength;
+
+            dataView.setUint32(offset, id.byteLength, true);
+            offset += 4;
+
+            var idArray = new Uint16Array(buffer, offset, id.length);
+            idArray.set(id);
+            offset += idArray.byteLength;
+
+            dataView.setUint32(offset, cert.byteLength, true);
+            offset += 4;
+
+            var certArray = new Uint8Array(buffer, offset, cert.byteLength);
+            certArray.set(cert);
+
+            return new Uint8Array(buffer, 0, buffer.byteLength);
+        },
+
+        onNeedKey = function(e) {
+            this.debug.info("[Stream] <video> needkey event", e);
+
+            var contentId = extractContentId(e.initData);
+            var initData = concatInitDataIdAndCertificate(e.initData, contentId, getCertificate());
+
+            var mediaKeys = new WebKitMediaKeys('com.apple.fps.1_0');
+            this.videoModel.getElement().webkitSetMediaKeys(mediaKeys);
+            var session = this.videoModel.getElement().webkitKeys.createSession('video/mp4', initData);
+            //mediaKeys.createSession('video/mp4', e.initData);
+
+            if (!session)
+                throw "Could not create key session";
+        },
+
+        onKeyMessage = function(e) {
+
+            this.debug.info("[Stream] <video> keymessage event", e);
+
+            var self = this,
+                needFailureReport = true,
+                session = event.target,
+                message = event.message,
+                laURL;
+
+            // var sessionId = event.sessionId;
+
+            if (protectionData && protectionData['com.apple.fps.1_0'] && protectionData['com.apple.fps.1_0'].laURL) {
+                laURL = protectionData['com.apple.fps.1_0'].laURL;
+            } else {
+                this.notify(MediaPlayer.dependencies.ProtectionController.eventList.ENAME_PROTECTION_ERROR,
+                    new MediaPlayer.vo.Error(MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_KEYMESSERR_URL_LICENSER_UNKNOWN, "No license server URL specified"));
+                return;
+            }
+
+            licenseRequest = new XMLHttpRequest();
+
+            licenseRequest.responseType = 'arraybuffer';
+            licenseRequest.session = session;
+
+            licenseRequest.onload = function() {
+
+                if (this.status < 200 || this.status > 299) {
+                    return;
+                }
+
+                if (this.status === 200 && this.readyState === 4) {
+                    self.debug.log("[DRM] Received license response");
+                    needFailureReport = false;
+
+                    // Response can be of the form: '\n<ckc>base64encoded</ckc>\n', so trim the excess
+                    var keyText = licenseRequest.responseText.trim();
+                    if (keyText.substr(0, 5) === '<ckc>' && keyText.substr(-6) === '</ckc>')
+                        keyText = keyText.slice(5,-6);
+                    // var key = base64DecodeUint8Array(keyText);
+                    var key = BASE64.decodeArray(keyText).buffer;
+                    session.update(key);
+                }
+            };
+
+            licenseRequest.onerror = licenseRequest.onloadend = function() {
+                if (!needFailureReport) {
+                    licenseRequest = null;
+                    return;
+                }
+                needFailureReport = false;
+
+                // Raise error only if request has not been aborted by reset
+                if (!this.aborted) {
+                    self.notify(MediaPlayer.dependencies.ProtectionController.eventList.ENAME_PROTECTION_ERROR,
+                        new MediaPlayer.vo.Error(MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_KEYMESSERR_LICENSER_ERROR, "License request failed", {
+                            url: laURL,
+                            status: this.status,
+                            error: this.response
+                        }));
+                }
+                licenseRequest = null;
+            };
+
+            var params = 'spc=' + btoa(String.fromCharCode.apply(null, message)) + '&assetId=' + encodeURIComponent(session.contentId);
+            licenseRequest.open('POST', laURL, true);
+            // request.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+            licenseRequest.setRequestHeader("Content-type", "application/octet-stream");
+            licenseRequest.send(params);
+        },
+
+        onKeyAdded = function(e) {
+            this.debug.info("[Stream] <video> keyadded event", e);
+        },
+
+        getKeyError = function(event) {
+            var code = MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_KEYERR,
+                msg = "MediakeyError";
+
+            if (event.errorCode) {
+                switch (event.errorCode.code) {
+                    case 1:
+                        code = MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_KEYERR_UNKNOWN;
+                        msg = "An unspecified error occurred. This value is used for errors that don't match any of the other codes.";
+                        break;
+                    case 2:
+                        code = MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_KEYERR_CLIENT;
+                        msg = "The Key System could not be installed or updated.";
+                        break;
+                    case 3:
+                        code = MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_KEYERR_SERVICE;
+                        msg = "The message passed into update indicated an error from the license service.";
+                        break;
+                    case 4:
+                        code = MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_KEYERR_OUTPUT;
+                        msg = "There is no available output device with the required characteristics for the content protection system.";
+                        break;
+                    case 5:
+                        code = MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_KEYERR_HARDWARECHANGE;
+                        msg += "A hardware configuration change caused a content protection error.";
+                        break;
+                    case 6:
+                        code = MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_KEYERR_DOMAIN;
+                        msg = "An error occurred in a multi-device domain licensing configuration. The most common error is a failure to join the domain.";
+                        break;
+                    default:
+                        code = MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_KEYERR_UNKNOWN;
+                        msg = "An unspecified error occurred. This value is used for errors that don't match any of the other codes.";
+                        break;
+                }
+            } else {
+                code = MediaPlayer.dependencies.ErrorHandler.prototype.MEDIA_KEYERR_UNKNOWN;
+                msg = "An unspecified error occurred. This value is used for errors that don't match any of the other codes.";
+            }
+            if (event.systemCode) {
+                msg += "  (System Code = " + event.systemCode + ")";
+            }
+            return new MediaPlayer.vo.protection.KeyError(code, msg);
+        },
+
+        onKeyError = function(e) {
+            this.debug.info("[Stream] <video> keyerror event", e);
+            this.notify(MediaPlayer.dependencies.ProtectionController.eventList.ENAME_PROTECTION_ERROR, getKeyError(e));
+        };
+
+    return {
+        system: undefined,
+        videoModel: undefined,
+        capabilities: undefined,
+        debug: undefined,
+        metricsExt: undefined,
+        errHandler: undefined,
+        metricsModel: undefined,
+        eventBus: undefined,
+        notify: undefined,
+
+        setup: function() {
+
+            playListener = onPlay.bind(this);
+            pauseListener = onPause.bind(this);
+            errorListener = onError.bind(this);
+            seekingListener = onSeeking.bind(this);
+            seekedListener = onSeeked.bind(this);
+            progressListener = onProgress.bind(this);
+            ratechangeListener = onRatechange.bind(this);
+            timeupdateListener = onTimeupdate.bind(this);
+            durationchangeListener = onDurationchange.bind(this);
+            loadedListener = onLoaded.bind(this);
+            loadeddataListener = onLoadedData.bind(this);
+            canplayListener = onCanPlay.bind(this);
+            playingListener = onPlaying.bind(this);
+            loadstartListener = onLoadStart.bind(this);
+
+            needKeyListener = onNeedKey.bind(this);
+            keyMessageListener = onKeyMessage.bind(this);
+            keyAddedListener = onKeyAdded.bind(this);
+            keyErrorListener = onKeyError.bind(this);
+
+            endedListener = onEnded.bind(this);
+        },
+
+        load: function(url) {
+            this.videoModel.setSource(url);
+        },
+
+        setVideoModel: function(value) {
+            this.videoModel = value;
+            this.videoModel.listen("play", playListener);
+            this.videoModel.listen("pause", pauseListener);
+            this.videoModel.listen("error", errorListener);
+            this.videoModel.listen("seeking", seekingListener);
+            this.videoModel.listen("seeked", seekedListener);
+            this.videoModel.listen("timeupdate", timeupdateListener);
+            this.videoModel.listen("durationchange", durationchangeListener);
+            this.videoModel.listen("progress", progressListener);
+            this.videoModel.listen("ratechange", ratechangeListener);
+            this.videoModel.listen("loadedmetadata", loadedListener);
+            this.videoModel.listen("loadeddata", loadeddataListener);
+            this.videoModel.listen("ended", endedListener);
+            this.videoModel.listen("canplay", canplayListener);
+            this.videoModel.listen("playing", playingListener);
+            this.videoModel.listen("loadstart", loadstartListener);
+
+            this.videoModel.listen("webkitneedkey", needKeyListener);
+            this.videoModel.listen("webkitkeymessage", keyMessageListener);
+            this.videoModel.listen("webkitkeyadded", keyAddedListener);
+            this.videoModel.listen("webkitkeyerror", keyErrorListener);
+        },
+
+        reset: function() {
+            this.debug.info("[Stream] Reset");
+
+            pause.call(this);
+
+            // Abort license request
+            if (licenseRequest) {
+                licenseRequest.aborted = true;
+                licenseRequest.abort();
+            }
+
+            this.videoModel.unlisten("play", playListener);
+            this.videoModel.unlisten("pause", pauseListener);
+            this.videoModel.unlisten("error", errorListener);
+            this.videoModel.unlisten("seeking", seekingListener);
+            this.videoModel.unlisten("seeked", seekedListener);
+            this.videoModel.unlisten("timeupdate", timeupdateListener);
+            this.videoModel.unlisten("durationchange", durationchangeListener);
+            this.videoModel.unlisten("progress", progressListener);
+            this.videoModel.unlisten("ratechange", ratechangeListener);
+            this.videoModel.unlisten("loadedmetadata", loadedListener);
+            this.videoModel.unlisten("loadeddata", loadeddataListener);
+            this.videoModel.unlisten("ended", endedListener);
+            this.videoModel.unlisten("canplay", canplayListener);
+            this.videoModel.unlisten("playing", playingListener);
+            this.videoModel.unlisten("loadstart", loadstartListener);
+
+            this.videoModel.unlisten("webkitneedkey", needKeyListener);
+            this.videoModel.unlisten("webkitkeymessage", keyMessageListener);
+            this.videoModel.unlisten("webkitkeyadded", keyAddedListener);
+            this.videoModel.unlisten("webkitkeyerror", keyErrorListener);
+
+            this.debug.info("[Stream] Reset source");
+            this.videoModel.setSource(null);
+            this.videoModel = null;
+
+            return Q.when(true);
+        },
+
+
+        setProtectionData: function(protData) {
+            protectionData = protData;
+        },
+
+        setInitialStartTime: function(startTime) {
+            var time = parseFloat(startTime);
+            if (!isNaN(time)) {
+                initialStartTime = time;
+            }
+        },
+
+        getAudioTracks: function() {
+            var audioTracks = [],
+                tracks = this.getVideoModel().getElement().audioTracks;
+            if (tracks.length === 0) {
+                return [];
+            }
+
+            for (var i = 0; i < tracks.length; i++) {
+                audioTracks.push({
+                    type: 'audio',
+                    id: tracks[i].id,
+                    lang: tracks[i].language
+                });
+            }
+            // this.debug.log('[Stream] audio track: ' + JSON.stringify(audioTracks));
+            return audioTracks;
+        },
+
+        setAudioLang: function(lang) {
+            this.debug.log('[Stream] Set audio lang: ' + lang);
+            var tracks = this.getVideoModel().getElement().audioTracks;
+            if (tracks.length === 0) {
+                return;
+            }
+            for (var i = 0; i < tracks.length; i++) {
+                if (lang === tracks[i].language) {
+                    tracks[i].enabled = true;
+                }
+            }
+        },
+
+        setAudioTrack: function(audioTrack) {
+            this.debug.log('[Stream] Set audio track: ' + audioTrack.lang);
+            var tracks = this.getVideoModel().getElement().audioTracks;
+            if (tracks.length === 0) {
+                return;
+            }
+            for (var i = 0; i < tracks.length; i++) {
+                if (audioTrack.id === tracks[i].id &&
+                    audioTrack.lang === tracks[i].language) {
+                    tracks[i].enabled = true;
+                }
+            }
+        },
+
+        getSelectedAudioTrack: function() {
+            var tracks = this.getVideoModel().getElement().audioTracks;
+            for (var i = 0; i < tracks.length; i++) {
+                if (tracks[i].enabled) {
+                    return {
+                        type: 'audio',
+                        id: tracks[i].id,
+                        lang: tracks[i].language
+                    };
+                }
+            }
+            return null;
+        },
+
+        getSubtitleTracks: function() {
+            var textTracks = [],
+                tracks = this.getVideoModel().getElement().textTracks;
+            if (tracks.length === 0) {
+                return [];
+            }
+
+            for (var i = 0; i < tracks.length; i++) {
+                textTracks.push({
+                    type: 'text',
+                    id: tracks[i].label,
+                    lang: tracks[i].language
+                });
+            }
+            // this.debug.log('[Stream] text track: ' + JSON.stringify(textTracks));
+            return textTracks;
+        },
+
+        enableSubtitles: function(enabled) {
+            subtitlesEnabled = enabled;
+            var tracks = this.getVideoModel().getElement().textTracks;
+            if (tracks.length === 0) {
+                return;
+            }
+
+            if (enabled) {
+                this.debug.log('[Stream] Set subtitle lang: ' + defaultSubtitleLang);
+            }
+
+            var found = false;
+            for (var i = 0; i < tracks.length; i++) {
+                if (enabled && defaultSubtitleLang === tracks[i].language) {
+                    tracks[i].mode = 'showing';
+                    found = true;
+                } else {
+                    tracks[i].mode = 'hidden';
+                }
+            }
+
+            if (enabled && !found) {
+                tracks[0].mode = "showing";
+            }
+        },
+
+        setSubtitleTrack: function(subtitleTrack) {
+            this.debug.log('[Stream] Set subtitle track: ' + subtitleTrack.lang);
+            var tracks = this.getVideoModel().getElement().textTracks;
+            if (tracks.length === 0) {
+                return;
+            }
+            for (var i = 0; i < tracks.length; i++) {
+                if (subtitleTrack.id === tracks[i].label &&
+                    subtitleTrack.lang === tracks[i].language) {
+                    tracks[i].mode = 'showing';
+                }
+            }
+        },
+
+        getSelectedSubtitleTrack: function() {
+            var tracks = this.getVideoModel().getElement().textTracks;
+            for (var i = 0; i < tracks.length; i++) {
+                if (tracks[i].mode === 'showing') {
+                    return {
+                        type: 'text',
+                        id: tracks[i].label,
+                        lang: tracks[i].language
+                    };
+                }
+            }
+            return null;
+        },
+
+        initProtection: function(/*protectionCtrl*/) {},
+
+        getVideoModel: function() {
+            return this.videoModel;
+        },
+
+        setAutoPlay: function(value) {
+            autoPlay = value;
+        },
+
+        setDefaultAudioLang: function(language) {
+            defaultAudioLang = language;
+        },
+
+        setDefaultSubtitleLang: function(language) {
+            defaultSubtitleLang = language;
+        },
+
+        getAutoPlay: function() {
+            return autoPlay;
+        },
+
+        getDuration: function() {
+            return this.videoModel.getDuration();
+        },
+
+        // Used by StreamController for periods transitions => NA
+        getStartTime: function() {return 0;},
+
+        getPeriodIndex: function() {return 0;},
+
+        getId: function() {return '';},
+
+        // Used by StreamController to compose streams => NA
+        getPeriodInfo: function() {return null;},
+
+        // Not used/called
+        getMinbufferTime: function() {return 0;},
+
+        // Not called since no DVR window range (see MediaPlayer::seek)
+        getLiveDelay: function() {return -1;},
+
+        // Not supported
+        startEventController: function() {},
+        resetEventController: function() {},
+
+        // Not supported
+        setTrickModeSpeed: function(/*speed*/) {},
+        getTrickModeSpeed: function() {return -1;},
+
+        // Used by StreamController to compose streams => NA
+        updateData: function() {},
+
+        play: play,
+        seek: seek,
+        pause: pause
+    };
+};
+
+Hls.dependencies.HlsStream.prototype = {
+    constructor: Hls.dependencies.HlsStream
+};

--- a/app/js/streaming/Context.js
+++ b/app/js/streaming/Context.js
@@ -120,6 +120,8 @@ MediaPlayer.di.Context = function () {
             this.system.mapClass('hlsParser', Hls.dependencies.HlsParser);
             this.system.mapSingleton('hlsDemux', Hls.dependencies.HlsDemux);
             // @endif
+            // But we do always provide HlsStream to support HLS(+FP) streams in Safari
+            this.system.mapClass('hlsStream', Hls.dependencies.HlsStream);
 
             // Create the context manager to plug some specific parts of the code
             this.system.mapSingleton('contextManager', MediaPlayer.modules.ContextManager);

--- a/app/js/streaming/Stream.js
+++ b/app/js/streaming/Stream.js
@@ -1142,6 +1142,10 @@ MediaPlayer.dependencies.Stream = function() {
             }
         },
 
+        getAudioTracks: function() {
+            return this.manifestExt.getAudioDatas(manifest, periodInfo.index);
+        },
+
         setAudioTrack: function(audioTrack) {
             if (fragmentInfoAudioController) {
                 fragmentInfoAudioController.stop();
@@ -1154,6 +1158,10 @@ MediaPlayer.dependencies.Stream = function() {
                 return this.manifestExt.getDataForIndex(audioTrackIndex, manifest, periodInfo.index);
             }
             return undefined;
+        },
+
+        getSubtitleTracks: function() {
+            return this.manifestExt.getTextDatas(manifest, periodInfo.index);
         },
 
         setSubtitleTrack: function(subtitleTrack) {

--- a/app/js/streaming/StreamController.js
+++ b/app/js/streaming/StreamController.js
@@ -35,9 +35,6 @@ MediaPlayer.dependencies.StreamController = function() {
         progressListener,
         pauseListener,
         playListener,
-        // ORANGE: audio language management
-        audioTracks,
-        subtitleTracks,
         protectionData,
         defaultAudioLang = 'und',
         defaultSubtitleLang = 'und',
@@ -359,23 +356,6 @@ MediaPlayer.dependencies.StreamController = function() {
             return true;
         },
 
-        // ORANGE: create function to handle audiotracks
-        updateAudioTracks = function() {
-            if (activeStream) {
-                audioTracks = this.manifestExt.getAudioDatas(this.manifestModel.getValue(), activeStream.getPeriodIndex());
-                // fire event to notify that audiotracks have changed
-                this.system.notify("audioTracksUpdated");
-            }
-        },
-
-        updateSubtitleTracks = function() {
-            if (activeStream) {
-                subtitleTracks = this.manifestExt.getTextDatas(this.manifestModel.getValue(), activeStream.getPeriodIndex());
-                // fire event to notify that subtitletracks have changed
-                this.system.notify("subtitleTracksUpdated");
-            }
-        },
-
         manifestUpdate = function(reload) {
             if (reload === true) {
                 reloadStream = true;
@@ -399,10 +379,6 @@ MediaPlayer.dependencies.StreamController = function() {
             var result = composeStreams.call(this);
 
             if (result) {
-                // ORANGE: Update Audio Tracks List
-                updateAudioTracks.call(this);
-                // ORANGE: Update Subtitle Tracks List
-                updateSubtitleTracks.call(this);
                 this.system.notify("streamsComposed");
             } else {
                 this.errHandler.sendError(MediaPlayer.dependencies.ErrorHandler.prototype.MANIFEST_ERR_NO_STREAM, "No stream/period is provided in the manifest");
@@ -465,7 +441,10 @@ MediaPlayer.dependencies.StreamController = function() {
         },
 
         getAudioTracks: function() {
-            return audioTracks;
+            if (activeStream) {
+                return activeStream.getAudioTracks();
+            }
+            return null;
         },
 
         getSelectedAudioTrack: function() {
@@ -484,7 +463,10 @@ MediaPlayer.dependencies.StreamController = function() {
         },
 
         getSubtitleTracks: function() {
-            return subtitleTracks;
+            if (activeStream) {
+                return activeStream.getSubtitleTracks();
+            }
+            return null;
         },
 
         setSubtitleTrack: function(subtitleTrack) {

--- a/app/js/streaming/StreamController.js
+++ b/app/js/streaming/StreamController.js
@@ -255,10 +255,9 @@ MediaPlayer.dependencies.StreamController = function() {
         },
 
         composeStreams = function() {
-            var self = this,
-                manifest = self.manifestModel.getValue(),
-                metrics = self.metricsModel.getMetricsFor("stream"),
-                manifestUpdateInfo = self.metricsExt.getCurrentManifestUpdate(metrics),
+            var manifest = this.manifestModel.getValue(),
+                metrics = this.metricsModel.getMetricsFor("stream"),
+                manifestUpdateInfo = this.metricsExt.getCurrentManifestUpdate(metrics),
                 periodInfo,
                 periods,
                 pLen,
@@ -275,10 +274,10 @@ MediaPlayer.dependencies.StreamController = function() {
 
             this.debug.info("[StreamController] composeStreams");
 
-            if (self.capabilities.supportsEncryptedMedia()) {
+            if (this.capabilities.supportsEncryptedMedia()) {
                 if (!protectionController) {
-                    protectionController = self.system.getObject("protectionController");
-                    /*self.eventBus.dispatchEvent({
+                    protectionController = this.system.getObject("protectionController");
+                    /*this.eventBus.dispatchEvent({
                         type: MediaPlayer.events.PROTECTION_CREATED,
                         data: {
                             controller: protectionController,
@@ -287,20 +286,20 @@ MediaPlayer.dependencies.StreamController = function() {
                     });*/
                     ownProtectionController = true;
                 }
-                protectionController.setMediaElement(self.videoModel.getElement());
+                protectionController.setMediaElement(this.videoModel.getElement());
                 if (protectionData) {
                     protectionController.setProtectionData(protectionData);
                 }
             }
 
-            mpd = self.manifestExt.getMpd(manifest);
+            mpd = this.manifestExt.getMpd(manifest);
             if (activeStream) {
                 periodInfo = activeStream.getPeriodInfo();
                 mpd.isClientServerTimeSyncCompleted = periodInfo.mpd.isClientServerTimeSyncCompleted;
                 mpd.clientServerTimeShift = periodInfo.mpd.clientServerTimeShift;
             }
 
-            periods = self.manifestExt.getRegularPeriods(manifest, mpd);
+            periods = this.manifestExt.getRegularPeriods(manifest, mpd);
             if (periods.length === 0) {
                 return false;
             }
@@ -319,8 +318,8 @@ MediaPlayer.dependencies.StreamController = function() {
                 // introduced in the updated manifest, so we need to create a new Stream and perform all the initialization operations
                 if (!stream) {
                     this.debug.info("[StreamController] Create stream");
-                    stream = self.system.getObject("stream");
-                    stream.setVideoModel(pIdx === 0 ? self.videoModel : createVideoModel.call(self));
+                    stream = this.system.getObject("stream");
+                    stream.setVideoModel(pIdx === 0 ? this.videoModel : createVideoModel.call(this));
                     stream.initProtection(protectionController);
                     stream.setAutoPlay(autoPlay);
                     stream.setDefaultAudioLang(defaultAudioLang);
@@ -331,19 +330,19 @@ MediaPlayer.dependencies.StreamController = function() {
                     streams.push(stream);
                 }
 
-                self.metricsModel.addManifestUpdatePeriodInfo(manifestUpdateInfo, period.id, period.index, period.start, period.duration);
+                this.metricsModel.addManifestUpdatePeriodInfo(manifestUpdateInfo, period.id, period.index, period.start, period.duration);
                 stream = null;
             }
 
             // If the active stream has not been set up yet, let it be the first Stream in the list
             if (!activeStream) {
                 activeStream = streams[0];
-                attachVideoEvents.call(self, activeStream.getVideoModel());
+                attachVideoEvents.call(this, activeStream.getVideoModel());
             }
 
-            self.metricsModel.updateManifestUpdateInfo(manifestUpdateInfo, {
-                currentTime: self.videoModel.getCurrentTime(),
-                buffered: self.videoModel.getElement().buffered,
+            this.metricsModel.updateManifestUpdateInfo(manifestUpdateInfo, {
+                currentTime: this.videoModel.getCurrentTime(),
+                buffered: this.videoModel.getElement().buffered,
                 presentationStartTime: periods[0].start,
                 clientTimeOffset: mpd.clientServerTimeShift
             });

--- a/app/js/streaming/VideoModel.js
+++ b/app/js/streaming/VideoModel.js
@@ -29,14 +29,8 @@ MediaPlayer.models.VideoModel = function () {
 
         stallStream = function (type, stalled) {
             stalledStreams[type] = stalled;
-
-            if (!isStalled()) {
-                this.debug.info("<video> setPlaybackRate(1)");
-                element.playbackRate = 1;
-            } else {
-                this.debug.info("<video> setPlaybackRate(0)");
-                element.playbackRate = 0;
-            }
+            this.debug.info("<video> # stalled = " + stalled + ", type = " + type);
+            this.setPlaybackRate(isStalled() ? 0 : 1);
         };
 
     return {
@@ -51,12 +45,12 @@ MediaPlayer.models.VideoModel = function () {
         },
 
         play: function () {
-            this.debug.info("<video> play()");
+            this.debug.info("<video> # play()");
             element.play();
         },
 
         pause: function () {
-            this.debug.info("<video> pause()");
+            this.debug.info("<video> # pause()");
             element.pause();
         },
 
@@ -77,7 +71,7 @@ MediaPlayer.models.VideoModel = function () {
         },
 
         setPlaybackRate: function (value) {
-            this.debug.info("<video> setPlaybackRate(" + value + ")");
+            this.debug.info("<video> # playbackRate = " + value);
             element.playbackRate = value;
         },
 
@@ -102,7 +96,7 @@ MediaPlayer.models.VideoModel = function () {
         },
 
         setCurrentTime: function (currentTime) {
-            this.debug.info("<video> setCurrentTime (" + currentTime + ")");
+            this.debug.info("<video> # currentTime = " + currentTime);
             element.currentTime = currentTime;
         },
 
@@ -133,8 +127,10 @@ MediaPlayer.models.VideoModel = function () {
 
         setSource: function (source) {
             if (source) {
+                this.debug.info("<video> # set source");
                 element.src = source;
             } else {
+                this.debug.info("<video> # reset source");
                 element.removeAttribute('src');
                 element.load();
             }

--- a/build/sources.json
+++ b/build/sources.json
@@ -78,7 +78,8 @@
         "../app/js/hls/HlsDemux.js",
         "../app/js/hls/HlsFragmentController.js",
         "../app/js/hls/HlsHandler.js",
-        "../app/js/hls/HlsParser.js"
+        "../app/js/hls/HlsParser.js",
+        "../app/js/hls/HlsStream.js"
     ],
     "mss": [
         "../app/js/mss/Mss.js",

--- a/samples/Dash-IF/index.html
+++ b/samples/Dash-IF/index.html
@@ -187,6 +187,8 @@
 <script src="../../app/js/hls/HlsParser.js"></script>
 <script src="../../app/js/hls/HlsHandler.js"></script>
 <script src="../../app/js/hls/HlsFragmentController.js"></script>
+<script src="../../app/js/hls/HlsStream.js"></script>
+
 
 <!-- /app/js/mss -->
 <script src="../../app/js/mss/Mss.js"></script>

--- a/samples/Dash-IF/json/sources.json
+++ b/samples/Dash-IF/json/sources.json
@@ -15,6 +15,20 @@
             "browsers": "cdsbi"
         },
         {
+            "type": "Live",
+            "protocol": "HLS",
+            "name": "HLS+FP (Sample)",
+            "url": "https://s3.amazonaws.com/shift72-temp/hls_fps_bento4_sintel/master.m3u8",
+            "browsers": "cdsbi",
+            "protData": {
+                "com.apple.fps.1_0": {
+                    "laURL": "https://staging-solo.shift72.com/services/license/fairplay/cenc/fallback",
+                    "requestType": "text",
+                    "serverCertificate": "MIIE6DCCA9CgAwIBAgIID828Ey6J/VYwDQYJKoZIhvcNAQEFBQAwfzELMAkGA1UEBhMCVVMxEzARBgNVBAoMCkFwcGxlIEluYy4xJjAkBgNVBAsMHUFwcGxlIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MTMwMQYDVQQDDCpBcHBsZSBLZXkgU2VydmljZXMgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkwHhcNMTcwMzIxMDI1ODI4WhcNMTkwMzIyMDI1ODI4WjBqMQswCQYDVQQGEwJVUzEYMBYGA1UECgwPU0hJRlQ3MiBMaW1pdGVkMRMwEQYDVQQLDApKVEE0Q1E5UzZHMSwwKgYDVQQDDCNGYWlyUGxheSBTdHJlYW1pbmc6IFNISUZUNzIgTGltaXRlZDCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAxpV7P7sJQxNDJ96mnsJ9NpyAXgGZWYI44jNkGY4cHMHVNTMEZSnIGcMFkULuHei8bF7aXbEkN9JYeM0RQ8L5UjolasC7ZukiulAp4DOXT13CjLvOLrWgofwRRh+ln1DFFjwgMmt88XQsELxVUXs6QZJ8SAHy6kDIxvdmkgD6glUCAwEAAaOCAf8wggH7MB0GA1UdDgQWBBSiq8XFFM7pvz+gWvj3sqbQ3vPspDAMBgNVHRMBAf8EAjAAMB8GA1UdIwQYMBaAFGPkR1TLhXFZRiyDrMxEMWRnAyy+MIHiBgNVHSAEgdowgdcwgdQGCSqGSIb3Y2QFATCBxjCBwwYIKwYBBQUHAgIwgbYMgbNSZWxpYW5jZSBvbiB0aGlzIGNlcnRpZmljYXRlIGJ5IGFueSBwYXJ0eSBhc3N1bWVzIGFjY2VwdGFuY2Ugb2YgdGhlIHRoZW4gYXBwbGljYWJsZSBzdGFuZGFyZCB0ZXJtcyBhbmQgY29uZGl0aW9ucyBvZiB1c2UsIGNlcnRpZmljYXRlIHBvbGljeSBhbmQgY2VydGlmaWNhdGlvbiBwcmFjdGljZSBzdGF0ZW1lbnRzLjA1BgNVHR8ELjAsMCqgKKAmhiRodHRwOi8vY3JsLmFwcGxlLmNvbS9rZXlzZXJ2aWNlcy5jcmwwDgYDVR0PAQH/BAQDAgUgMEIGCyqGSIb3Y2QGDQEDAQH/BDABcnh0dHp3a2gzNWxoZmhncGt3MnYwYWlranlocXBnOXhnMm1ubnlmenpyYzZ6MXAwOwYLKoZIhvdjZAYNAQQBAf8EKQF5b3oxMXFibnFzc2d4cWl2aW1ianFjNzVlY3B6eXZ0a2V4ZjhmMm1tMA0GCSqGSIb3DQEBBQUAA4IBAQDCT5EfYh1xGp9hioTZt65/6Q1Xua37lQwgR83kolbbQGss8nIzez2nizT3mfCWOz6BCucuNLNSqeEMu3pn75rrJFHMlz5X8AEyLa828SQ/tlxH5zFYpfTVbGkMIw6awdssTiTmScLIwooHjFgcXu0dtqoBUrCrXWVHfiSlQA+QEo4BzFkKvAfWtXpDGEBYl+kbmoEFwzwCPhO7bWXbxUPkBVe8YpdSN+TZZDoZNo/2nZ/cEnBmo+W6InkPz8gwmNRrCJjhx94AVhxyf5ZjJ057RryNXDlLMIygiPfhciZ0PFi+MBA+P3sEwo2PaZxsqu44qyLl63AdFvItJiI9JgGn"
+                }
+            }
+        },
+        {
             "type": "VOD",
             "protocol": "MSS",
             "name": "VOD - SuperSpeedway",

--- a/samples/DemoPlayer/index.html
+++ b/samples/DemoPlayer/index.html
@@ -633,6 +633,7 @@
 <script src="../../app/js/hls/HlsParser.js"></script>
 <script src="../../app/js/hls/HlsHandler.js"></script>
 <script src="../../app/js/hls/HlsFragmentController.js"></script>
+<script src="../../app/js/hls/HlsStream.js"></script>
 
 <!-- /app/js/mss -->
 <script src="../../app/js/mss/Mss.js"></script>


### PR DESCRIPTION
Provide support for HLS on Safari/OSx, enabling support for HLS+FairPlay.
With this PR, streaming and decoding is performed directly by the &lt;video&gt; element without using MSE, but using EME for exchanges between licenser and FairPlay CDM.