### PR TITLE
Start-over

### DIFF
--- a/app/js/mss/MssFragmentController.js
+++ b/app/js/mss/MssFragmentController.js
@@ -88,7 +88,7 @@ Mss.dependencies.MssFragmentController = function() {
 
             // Update segment timeline according to DVR window
             if (manifest.timeShiftBufferDepth && manifest.timeShiftBufferDepth > 0) {
-                if (segmentsUpdated) {
+                if (segmentsUpdated && manifest.startOver !== true) {
                     // Get timestamp of the last segment
                     segment = segments[segments.length - 1];
                     t = segment.t;

--- a/app/js/mss/MssParser.js
+++ b/app/js/mss/MssParser.js
@@ -505,6 +505,15 @@ Mss.dependencies.MssParser = function() {
             mpd.type = (isLive !== null && isLive.toLowerCase() === 'true') ? 'dynamic' : 'static';
             mpd.timeShiftBufferDepth = parseFloat(this.domParser.getAttributeValue(smoothNode, 'DVRWindowLength')) / TIME_SCALE_100_NANOSECOND_UNIT;
             var duration = parseFloat(this.domParser.getAttributeValue(smoothNode, 'Duration'));
+
+            // If live manifest with Duration and no DVRWindowLength, we consider it as a start-over manifest
+            if (mpd.type === "dynamic" && duration > 0) {
+                mpd.timeShiftBufferDepth = duration / TIME_SCALE_100_NANOSECOND_UNIT;
+                duration = 0;
+                mpd.startOver = true;
+            }
+
+            // Complete manifest/mpd initialization
             mpd.mediaPresentationDuration = (duration === 0) ? Infinity : (duration / TIME_SCALE_100_NANOSECOND_UNIT);
             mpd.BaseURL = baseURL;
             mpd.minBufferTime = MediaPlayer.dependencies.BufferExtensions.DEFAULT_MIN_BUFFER_TIME;

--- a/app/js/streaming/MediaPlayer.js
+++ b/app/js/streaming/MediaPlayer.js
@@ -844,6 +844,7 @@ MediaPlayer = function () {
             {
                 url : "[manifest url]",
                 startTime : [start time in seconds (optional, only for static streams)],
+                startOver : [true if start-over DVR stream (optional)],
                 protocol : "[protocol type]", // 'HLS' to activate native support on Safari/OSx
                 protData : {
                     // one entry for each key system ('com.microsoft.playready' or 'com.widevine.alpha')

--- a/app/js/streaming/StreamController.js
+++ b/app/js/streaming/StreamController.js
@@ -269,6 +269,12 @@ MediaPlayer.dependencies.StreamController = function() {
                 return false;
             }
 
+            // Specific use case of "start-over" or "session DVR" live streams
+            // We set this information in the manifest, to be used by MssFragmentController for DVR window updating
+            if (source.startOver) {
+                manifest.startOver = true;
+            } 
+
             this.debug.info("[StreamController] composeStreams");
 
             if (this.capabilities.supportsEncryptedMedia()) {


### PR DESCRIPTION
This PR provides support for MSS start-over streams, i.e. live stream that allow to seek back to the start of the program.
Start-over streams manifests are live manifest without DVRWindowLength but with Duration field value, which is then interpreted as the starting DVR window length.
The particularity of start-over streams is that the DVR window range start is not increasing while range end is increasing as usual live streams.
Then it is possible for user to seek back to the beginning of the program.
