### PR TITLE
Bug fix on metrics persistence

### DIFF
--- a/app/js/streaming/BufferController.js
+++ b/app/js/streaming/BufferController.js
@@ -1511,14 +1511,6 @@ MediaPlayer.dependencies.BufferController = function() {
             return isBufferingCompleted;
         },
 
-        clearMetrics: function() {
-            if (type === null || type === "") {
-                return;
-            }
-
-            this.metricsModel.clearCurrentMetricsForType(type);
-        },
-
         updateManifest: function() {
             this.system.notify("manifestUpdate");
         },
@@ -1649,7 +1641,6 @@ MediaPlayer.dependencies.BufferController = function() {
                         fragmentModel = null;
                     }
 
-                    self.clearMetrics();
                     initializationData = [];
                     initialPlayback = true;
                     isQuotaExceeded = false;

--- a/app/js/streaming/MetricsModel.js
+++ b/app/js/streaming/MetricsModel.js
@@ -50,29 +50,24 @@
             this.metricChanged(streamType);
         },
 
-        clearCurrentMetricsForType: function (type) {
-            var keepBW = this.config.getParamFor(type, "ABR.keepBandwidthCondition", "boolean", true);
-
-            for (var prop in this.streamMetrics[type]) {
-                // We keep HttpList in order to keep bandwidth conditions when switching the input stream
-                if (this.streamMetrics[type].hasOwnProperty(prop) && ((prop !== "HttpList") || (keepBW === false))) {
-                    this.streamMetrics[type][prop] = [];
-                }
-            }
-
-            this.metricChanged(type);
-        },
-
         clearAllCurrentMetrics: function () {
             var self = this;
 
-            for (var prop in this.streamMetrics) {
-                if (this.streamMetrics.hasOwnProperty(prop) && (prop === "stream")) {
-                    delete this.streamMetrics[prop];
+            for (var type in this.streamMetrics) {
+                if (this.streamMetrics.hasOwnProperty(type) && (type === "stream")) {
+                    delete this.streamMetrics[type];
+                } else {
+                    var keepBW = this.config.getParamFor(type, "ABR.keepBandwidthCondition", "boolean", true);
+
+                    for (var prop in this.streamMetrics[type]) {
+                        // We keep HttpList in order to keep bandwidth conditions when switching the input stream
+                        if (this.streamMetrics[type].hasOwnProperty(prop) && ((prop !== "HttpList") || (keepBW === false))) {
+                            this.streamMetrics[type][prop] = [];
+                        }
+                    }
                 }
             }
 
-            //this.streamMetrics = {};
             this.metricsChanged.call(self);
         },
 


### PR DESCRIPTION
clearAllCurrentMetrics function is called by the StreamController. This function has to delete all metrics data except httpList metrics for audio and video types.

Thereby, two consecutive errors on manifest access are well traced by metrics datas.