### PR TITLE
Audio switch bug fix

### DIFF
--- a/app/js/dash/DashManifestExtensions.js
+++ b/app/js/dash/DashManifestExtensions.js
@@ -21,6 +21,12 @@ Dash.dependencies.DashManifestExtensions = function() {
 Dash.dependencies.DashManifestExtensions.prototype = {
     constructor: Dash.dependencies.DashManifestExtensions,
 
+    isInteger: Number.isInteger || function (value) {
+        return typeof value === 'number' &&
+            isFinite(value) &&
+            Math.floor(value) === value;
+    },
+
     getIsType: function(adaptation, type, mimeTypes) {
         "use strict";
         var i, j,
@@ -416,7 +422,7 @@ Dash.dependencies.DashManifestExtensions.prototype = {
 
     getBandwidth: function(representation) {
         "use strict";
-        return representation.bandwidth;
+        return representation && representation.bandwidth ? representation.bandwidth : NaN;
     },
 
     getRefreshDelay: function(manifest) {
@@ -442,7 +448,8 @@ Dash.dependencies.DashManifestExtensions.prototype = {
 
     getRepresentationFor: function(index, data) {
         "use strict";
-        return data.Representation_asArray[index];
+        return data && data.Representation_asArray && data.Representation_asArray.length > 0 &&
+            this.isInteger(index) && index < data.Representation_asArray.length ? data.Representation_asArray[index] : null;
     },
 
     getRepresentationsForAdaptation: function(manifest, adaptation) {


### PR DESCRIPTION
protects getBandwith and getRepresentationFor of unexpected parameters.
bug fix on audio switch with stream : rdmedia.bbc.co.uk/dash/ondemand/testcard/1/client_manifest-events.mpd