### PR TITLE
Avoid seeking to end of stream (= duration)

### DIFF
--- a/app/js/mss/MssFragmentController.js
+++ b/app/js/mss/MssFragmentController.js
@@ -136,8 +136,7 @@ Mss.dependencies.MssFragmentController = function() {
                 traf = null,
                 tfdt = null,
                 tfrf = null,
-                pos,
-                i = 0;
+                pos;
 
             // Create new fragment
             fragment = mp4lib.deserialize(bytes);

--- a/app/js/streaming/captioning/TextTTMLXMLMP4SourceBuffer.js
+++ b/app/js/streaming/captioning/TextTTMLXMLMP4SourceBuffer.js
@@ -98,6 +98,7 @@ MediaPlayer.dependencies.TextTTMLXMLMP4SourceBuffer = function() {
         ttmlParser: undefined,
         debug: undefined,
         manifestModel: undefined,
+        errHandler: undefined,
 
         initialize: function(type, bufferController, subtitleData) {
             mimeType = type;
@@ -167,8 +168,8 @@ MediaPlayer.dependencies.TextTTMLXMLMP4SourceBuffer = function() {
                                     type: "updateend"
                                 });
                             }
-                        }, function( /*error*/ ) {
-                            //self.debug.error("[TextTTMLXMLMP4SourceBuffer] error parsing TTML "+error);
+                        }, function(error) {
+                            self.errHandler.sendWarning(MediaPlayer.dependencies.ErrorHandler.prototype.INTERNAL_ERROR, "Internal error while parsing TTML data", error);
                         });
                     });
                 return;
@@ -253,8 +254,8 @@ MediaPlayer.dependencies.TextTTMLXMLMP4SourceBuffer = function() {
                                     type: "updateend"
                                 });
                             }
-                        }, function( /*error*/ ) {
-                            //self.debug.error("[TextTTMLXMLMP4SourceBuffer] error parsing TTML "+error);
+                        }, function(error) {
+                            self.errHandler.sendWarning(MediaPlayer.dependencies.ErrorHandler.prototype.INTERNAL_ERROR, "Internal error while parsing TTML data", error);
                         });
                     });
             }


### PR DESCRIPTION
This PR gets around an issue when seeking at end of stream (= duration) which does not work consistently across browsers ('ended' event is not always raised).
When seeking to end, we do seek 2 sec. backward to enable 'ended' event to be raised.