### PR TITLE
Correct MSS parsing

### DIFF
--- a/app/js/mss/MssParser.js
+++ b/app/js/mss/MssParser.js
@@ -328,6 +328,7 @@ Mss.dependencies.MssParser = function() {
                        } else {
                            prevSegment.d = segment.t - prevSegment.t;
                        }
+                       duration += prevSegment.d;
                     }
                     // Set segment absolute timestamp if not set in manifest
                     if (!segment.t) {
@@ -340,7 +341,9 @@ Mss.dependencies.MssParser = function() {
                     }
                 }
 
-                duration += segment.d;
+                if (segment.d) {
+                    duration += segment.d;
+                }
 
                 // Create new segment
                 segments.push(segment);


### PR DESCRIPTION
This PR corrects MSS parsing if 'd' not defined for 1st segment for static streams.
Should resolve issue #234 