### PR TITLE
Missing DVRWindowLength field for live streams

### DIFF
--- a/app/js/mss/MssParser.js
+++ b/app/js/mss/MssParser.js
@@ -570,9 +570,9 @@ Mss.dependencies.MssParser = function() {
             mpd.timescale = timescale ? parseFloat(timescale) : DEFAULT_TIME_SCALE;
             var isLive = this.domParser.getAttributeValue(smoothNode, 'IsLive');
             mpd.type = (isLive !== null && isLive.toLowerCase() === 'true') ? 'dynamic' : 'static';
-            var canSeek = this.domParser.getAttributeValue(smoothNode, 'CanSeek');
+            // var canSeek = this.domParser.getAttributeValue(smoothNode, 'CanSeek');
             var dvrWindowLength = parseFloat(this.domParser.getAttributeValue(smoothNode, 'DVRWindowLength'));
-            if (dvrWindowLength === 0 && canSeek !== null && canSeek.toLowerCase() === 'true') {
+            if (dvrWindowLength === 0 || isNaN(dvrWindowLength)) {
                 dvrWindowLength = Infinity;
             }
             mpd.timeShiftBufferDepth = dvrWindowLength / mpd.timescale;

--- a/app/js/mss/MssParser.js
+++ b/app/js/mss/MssParser.js
@@ -572,7 +572,7 @@ Mss.dependencies.MssParser = function() {
             mpd.type = (isLive !== null && isLive.toLowerCase() === 'true') ? 'dynamic' : 'static';
             // var canSeek = this.domParser.getAttributeValue(smoothNode, 'CanSeek');
             var dvrWindowLength = parseFloat(this.domParser.getAttributeValue(smoothNode, 'DVRWindowLength'));
-            if (dvrWindowLength === 0 || isNaN(dvrWindowLength)) {
+            if (isLive && (dvrWindowLength === 0 || isNaN(dvrWindowLength))) {
                 dvrWindowLength = Infinity;
             }
             mpd.timeShiftBufferDepth = dvrWindowLength / mpd.timescale;


### PR DESCRIPTION
If DVRWindow field is omitted for a live presentation or set to 0, the DVR window is effectively infinite.